### PR TITLE
Fix type display names for multidimensional arrays

### DIFF
--- a/src/ProfileTool/Rendering/NameFormatter.cs
+++ b/src/ProfileTool/Rendering/NameFormatter.cs
@@ -79,9 +79,19 @@ public static class NameFormatter
             timeout);
 
         const string arrayToken = "__ARRAY__";
-        normalized = normalized.Replace("[]", arrayToken, StringComparison.Ordinal);
+        normalized = Regex.Replace(
+            normalized,
+            @"\[(?<commas>,*)\]",
+            match => $"{arrayToken}{match.Groups["commas"].Value}{arrayToken}",
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
         normalized = normalized.Replace('[', '<').Replace(']', '>');
-        normalized = normalized.Replace(arrayToken, "[]", StringComparison.Ordinal);
+        normalized = Regex.Replace(
+            normalized,
+            $"{arrayToken}(?<commas>,*){arrayToken}",
+            match => $"[{match.Groups["commas"].Value}]",
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
         normalized = normalized.Replace('+', '.');
 
         return normalized;

--- a/tests/Asynkron.Profiler.Tests/NameFormatterTests.cs
+++ b/tests/Asynkron.Profiler.Tests/NameFormatterTests.cs
@@ -24,6 +24,9 @@ public sealed class NameFormatterTests
     [Theory]
     [InlineData("System.Collections.Generic.Dictionary`2[System.String,System.Int32]", "Dictionary<String,Int32>")]
     [InlineData("System.String[]", "String[]")]
+    [InlineData("System.Int32[,]", "Int32[,]")]
+    [InlineData("System.Collections.Generic.Dictionary`2[System.String,System.Int32[,]]",
+        "Dictionary<String,Int32[,]>")]
     public void FormatsTypeNames(string raw, string expected)
     {
         var actual = NameFormatter.FormatTypeDisplayName(raw);


### PR DESCRIPTION
## Summary
- preserve multidimensional array rank specifiers when formatting type display names
- add coverage for arrays inside generic type names

## Testing
- dotnet test