### PR TITLE
Remove hardcoded tool project version

### DIFF
--- a/src/ProfileTool/ProfileTool.csproj
+++ b/src/ProfileTool/ProfileTool.csproj
@@ -8,7 +8,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>asynkron-profiler</ToolCommandName>
     <PackageId>asynkron-profiler</PackageId>
-    <Version>0.1.10</Version>
     <Authors>Asynkron</Authors>
     <Description>Lightweight CLI for CPU, memory allocation, exception, lock contention, and heap profiling of .NET commands.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Asynkron.Profiler.Tests/ProfileToolProjectTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfileToolProjectTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class ProfileToolProjectTests
+{
+    [Fact]
+    public void ToolProjectDoesNotHardcodeVersion()
+    {
+        var repoRoot = FindRepoRoot();
+        var projectPath = Path.Combine(repoRoot, "src", "ProfileTool", "ProfileTool.csproj");
+
+        Assert.True(File.Exists(projectPath), $"Missing tool project at {projectPath}.");
+
+        var document = XDocument.Load(projectPath);
+        var rootNamespace = document.Root?.Name.Namespace ?? XNamespace.None;
+        var versionElements = document.Descendants(rootNamespace + "Version");
+
+        Assert.Empty(versionElements);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Asynkron.Profiler.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repo root from test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary
- remove the hardcoded package version from the tool project
- add a test to ensure the tool project does not define a Version element

## Testing
- dotnet test Asynkron.Profiler.sln

Fixes #2