### PR TITLE
ci: allow .NET 10 preview installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+          include-prerelease: true
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -31,6 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+          include-prerelease: true
       - name: Pack (dry run)
         run: |
           VERSION="0.0.0-ci.${GITHUB_RUN_NUMBER}"

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+          include-prerelease: true
       - name: Pack
         run: |
           VERSION="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Summary\n- allow actions/setup-dotnet to install preview SDKs when global.json targets .NET 10 preview\n- align pack workflow with CI setup\n\n## Testing\n- dotnet test -c Release --nologo\n\nFixes #4