### PR TITLE
Validate tag-based pack workflow

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -14,11 +14,33 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Pack
+      - name: Resolve version
+        id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "$GITHUB_REF_NAME" ]; then
+            echo "Tag must start with v and include a version (example: v1.2.3)."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Pack
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
           dotnet pack -c Release -o ./nupkg src/ProfileTool/ProfileTool.csproj -p:Version="$VERSION"
           dotnet pack -c Release -o ./nupkg src/ProfilerCore/Asynkron.Profiler.Core.csproj -p:Version="$VERSION"
+      - name: Validate package versions
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          expected=".$VERSION.nupkg"
+          for package in ./nupkg/*.nupkg; do
+            name="$(basename "$package")"
+            if [[ "$name" != *"$expected" ]]; then
+              echo "Package $name does not match version $VERSION."
+              exit 1
+            fi
+          done
       - name: Publish to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/tests/Asynkron.Profiler.Tests/ReleaseWorkflowTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ReleaseWorkflowTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class ReleaseWorkflowTests
+{
+    [Fact]
+    public void PackWorkflowUsesTagVersion()
+    {
+        var workflowContents = LoadPackWorkflow();
+
+        Assert.Contains("tags:", workflowContents, StringComparison.Ordinal);
+        Assert.Contains("v*", workflowContents, StringComparison.Ordinal);
+        Assert.Contains("GITHUB_REF_NAME#v", workflowContents, StringComparison.Ordinal);
+        Assert.Contains("-p:Version", workflowContents, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PackWorkflowValidatesPackageVersions()
+    {
+        var workflowContents = LoadPackWorkflow();
+
+        Assert.Contains("Validate package versions", workflowContents, StringComparison.Ordinal);
+        Assert.Contains("./nupkg/*.nupkg", workflowContents, StringComparison.Ordinal);
+    }
+
+    private static string LoadPackWorkflow()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "pack.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Missing pack workflow at {workflowPath}.");
+
+        return File.ReadAllText(workflowPath);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Asynkron.Profiler.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repo root from test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary\n- resolve tag version once and validate it against produced packages\n- add workflow tests to guard tag/version handling\n\n## Testing\n- dotnet test -c Release --nologo