### PR TITLE
docs: expand troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,18 +272,26 @@ Object Bytes  Count  Type
 
 ### Prerequisites checklist
 
-- .NET SDK 10.x installed (`dotnet --list-sdks`).
+- .NET SDK 10.x preview installed (`dotnet --list-sdks`). The repo pins a preview SDK in `global.json`.
 - Global tools installed and on `PATH`: `asynkron-profiler`, `dotnet-trace`, `dotnet-gcdump`.
   - Default tool paths: `~/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\\.dotnet\\tools` (Windows).
 - Prefer running the built output (Release) instead of `dotnet run` to avoid build/restore noise.
 
 ### Common failures
 
+- `It was not possible to find any compatible framework version`: install the .NET 10 preview runtime/SDK or update your PATH so `dotnet` resolves the preview SDK required by `global.json`.
 - `dotnet-trace` not found: install with `dotnet tool install -g dotnet-trace`, then ensure the global tool path is on `PATH`.
 - `dotnet-gcdump` not found: install with `dotnet tool install -g dotnet-gcdump`.
 - `Failed to create session` or `Diagnostics IPC error`: the target process must allow diagnostics. Ensure it is not started with `DOTNET_EnableDiagnostics=0` or `COMPlus_EnableDiagnostics=0` and run as the same user.
 - No data or empty allocation tables: run with `--memory` (GC allocation ticks) or provide a `.nettrace`/`.etlx` that includes GC allocation events.
 - Slow or huge traces: reduce workload/iterations or add app-side filters, then re-run.
+
+### References
+
+- CI workflow (SDK/runtime versions): https://github.com/asynkron/Asynkron.Profiler/actions/workflows/ci.yml
+- `dotnet-trace` docs: https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-trace
+- `dotnet-gcdump` docs: https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-gcdump
+- Diagnostics IPC overview: https://learn.microsoft.com/dotnet/core/diagnostics/diagnostics-client-library
 
 ## Examples
 


### PR DESCRIPTION
## Summary\n- document .NET 10 preview requirement in troubleshooting\n- add common failure for missing preview runtime/SDK\n- link to CI workflow and diagnostics docs\n\n## Testing\n- not run (docs only)\n\nFixes #8