### PR TITLE
Refactor profile input loading into focused components

### DIFF
--- a/src/ProfileTool/HeapProfileInputLoader.cs
+++ b/src/ProfileTool/HeapProfileInputLoader.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed class HeapProfileInputLoader
+{
+    private readonly ProfileInputDiagnostics _diagnostics;
+    private readonly Func<Theme> _getTheme;
+    private readonly Func<string, string, bool> _ensureToolAvailable;
+    private readonly Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> _runProcess;
+    private readonly Func<string, HeapProfileResult> _parseGcdumpReport;
+    private readonly Action<string> _writeLine;
+    private readonly string _dotnetGcdumpInstallHint;
+
+    public HeapProfileInputLoader(
+        Func<Theme> getTheme,
+        ProfileInputDiagnostics diagnostics,
+        Func<string, string, bool> ensureToolAvailable,
+        Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> runProcess,
+        Func<string, HeapProfileResult> parseGcdumpReport,
+        Action<string> writeLine,
+        string dotnetGcdumpInstallHint)
+    {
+        _diagnostics = diagnostics;
+        _getTheme = getTheme;
+        _ensureToolAvailable = ensureToolAvailable;
+        _runProcess = runProcess;
+        _parseGcdumpReport = parseGcdumpReport;
+        _writeLine = writeLine;
+        _dotnetGcdumpInstallHint = dotnetGcdumpInstallHint;
+    }
+
+    public HeapProfileResult? Load(string inputPath)
+    {
+        if (!TryEnsureInputExists(inputPath))
+        {
+            return null;
+        }
+
+        var extension = ProfileInputConventions.GetNormalizedExtension(inputPath);
+        if (extension == ".gcdump")
+        {
+            if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
+            {
+                return null;
+            }
+
+            return GcdumpReportLoader.Load(
+                inputPath,
+                _getTheme(),
+                _runProcess,
+                _parseGcdumpReport,
+                _writeLine);
+        }
+
+        if (extension is ".txt" or ".log")
+        {
+            return _parseGcdumpReport(File.ReadAllText(inputPath));
+        }
+
+        _diagnostics.WriteUnsupportedInput("Unsupported heap input", inputPath);
+        return null;
+    }
+
+    private bool TryEnsureInputExists(string inputPath)
+    {
+        return _diagnostics.TryEnsureInputExists(inputPath);
+    }
+}

--- a/src/ProfileTool/ProfileCollectionRunner.cs
+++ b/src/ProfileTool/ProfileCollectionRunner.cs
@@ -128,7 +128,7 @@ internal sealed class ProfileCollectionRunner
             },
             _profileInputLoader.AnalyzeAllocationTrace);
 
-        return callTree == null ? null : ProfileInputLoader.BuildMemoryProfileResult(callTree);
+        return callTree == null ? null : ProfileMemoryResultFactory.Build(callTree);
     }
 
     public ExceptionProfileResult? RunExceptionProfile(string[] command, string label)

--- a/src/ProfileTool/ProfileInputConventions.cs
+++ b/src/ProfileTool/ProfileInputConventions.cs
@@ -1,0 +1,55 @@
+using System.IO;
+
+namespace Asynkron.Profiler;
+
+internal static class ProfileInputConventions
+{
+    public static string BuildLabel(string inputPath)
+    {
+        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
+    }
+
+    public static void ApplyDefaults(
+        string inputPath,
+        ref bool runCpu,
+        ref bool runMemory,
+        ref bool runHeap,
+        ref bool runException,
+        ref bool runContention)
+    {
+        switch (GetNormalizedExtension(inputPath))
+        {
+            case ".json":
+                runCpu = true;
+                break;
+            case ".nettrace":
+                runCpu = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ".etlx":
+                runMemory = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ".gcdump":
+            case ".txt":
+            case ".log":
+                runHeap = true;
+                break;
+            default:
+                runCpu = true;
+                break;
+        }
+    }
+
+    public static string GetNormalizedExtension(string inputPath)
+    {
+        return Path.GetExtension(inputPath).ToLowerInvariant();
+    }
+
+    public static bool IsTraceExtension(string extension)
+    {
+        return extension is ".nettrace" or ".etlx";
+    }
+}

--- a/src/ProfileTool/ProfileInputDiagnostics.cs
+++ b/src/ProfileTool/ProfileInputDiagnostics.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfileInputDiagnostics
+{
+    private readonly Func<Theme> _getTheme;
+    private readonly Action<string> _writeLine;
+
+    public ProfileInputDiagnostics(Func<Theme> getTheme, Action<string> writeLine)
+    {
+        _getTheme = getTheme;
+        _writeLine = writeLine;
+    }
+
+    public bool TryEnsureInputExists(string inputPath)
+    {
+        if (File.Exists(inputPath))
+        {
+            return true;
+        }
+
+        _writeLine($"[{_getTheme().ErrorColor}]Input file not found:[/] {Markup.Escape(inputPath)}");
+        return false;
+    }
+
+    public void WriteUnsupportedInput(string message, string inputPath)
+    {
+        _writeLine($"[{_getTheme().ErrorColor}]{message}:[/] {Markup.Escape(inputPath)}");
+    }
+}

--- a/src/ProfileTool/ProfileInputLoader.cs
+++ b/src/ProfileTool/ProfileInputLoader.cs
@@ -1,22 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using Spectre.Console;
-using static Asynkron.Profiler.CallTreeHelpers;
-
 namespace Asynkron.Profiler;
 
 internal sealed class ProfileInputLoader
 {
-    private readonly ProfilerTraceAnalyzer _traceAnalyzer;
-    private readonly Func<Theme> _getTheme;
-    private readonly Func<string, string, bool> _ensureToolAvailable;
-    private readonly Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> _runProcess;
-    private readonly Func<string, HeapProfileResult> _parseGcdumpReport;
-    private readonly Action<string> _writeLine;
-    private readonly string _dotnetGcdumpInstallHint;
+    private readonly HeapProfileInputLoader _heapLoader;
+    private readonly ProfileTraceLoader _traceLoader;
 
     public ProfileInputLoader(
         ProfilerTraceAnalyzer traceAnalyzer,
@@ -27,280 +14,60 @@ internal sealed class ProfileInputLoader
         Action<string> writeLine,
         string dotnetGcdumpInstallHint)
     {
-        _traceAnalyzer = traceAnalyzer;
-        _getTheme = getTheme;
-        _ensureToolAvailable = ensureToolAvailable;
-        _runProcess = runProcess;
-        _parseGcdumpReport = parseGcdumpReport;
-        _writeLine = writeLine;
-        _dotnetGcdumpInstallHint = dotnetGcdumpInstallHint;
+        var diagnostics = new ProfileInputDiagnostics(getTheme, writeLine);
+        _traceLoader = new ProfileTraceLoader(traceAnalyzer, getTheme, diagnostics, writeLine);
+        _heapLoader = new HeapProfileInputLoader(
+            getTheme,
+            diagnostics,
+            ensureToolAvailable,
+            runProcess,
+            parseGcdumpReport,
+            writeLine,
+            dotnetGcdumpInstallHint);
     }
 
     public CpuProfileResult? LoadCpu(string inputPath)
     {
-        if (!TryEnsureInputExists(inputPath))
-        {
-            return null;
-        }
-
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".json")
-        {
-            return AnalyzeSpeedscope(inputPath);
-        }
-
-        if (!IsSupportedExtension(extension, ".nettrace", ".etlx"))
-        {
-            WriteUnsupportedInput("Unsupported CPU input", inputPath);
-            return null;
-        }
-
-        return AnalyzeCpuTrace(inputPath);
+        return _traceLoader.LoadCpu(inputPath);
     }
 
     public MemoryProfileResult? LoadMemory(string inputPath)
     {
-        if (!TryValidateTraceInput(inputPath, "Unsupported memory input"))
-        {
-            return null;
-        }
-
-        var callTree = AnalyzeAllocationTrace(inputPath);
-        return callTree == null ? null : BuildMemoryProfileResult(callTree);
+        return _traceLoader.LoadMemory(inputPath);
     }
 
     public ExceptionProfileResult? LoadException(string inputPath)
     {
-        if (!TryValidateTraceInput(inputPath, "Unsupported exception input"))
-        {
-            return null;
-        }
-
-        return AnalyzeExceptionTrace(inputPath);
+        return _traceLoader.LoadException(inputPath);
     }
 
     public ContentionProfileResult? LoadContention(string inputPath)
     {
-        if (!TryValidateTraceInput(inputPath, "Unsupported contention input"))
-        {
-            return null;
-        }
-
-        return AnalyzeContentionTrace(inputPath);
+        return _traceLoader.LoadContention(inputPath);
     }
 
     public HeapProfileResult? LoadHeap(string inputPath)
     {
-        if (!TryEnsureInputExists(inputPath))
-        {
-            return null;
-        }
-
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".gcdump")
-        {
-            if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
-            {
-                return null;
-            }
-
-            return GcdumpReportLoader.Load(
-                inputPath,
-                _getTheme(),
-                _runProcess,
-                _parseGcdumpReport,
-                _writeLine);
-        }
-
-        if (extension is ".txt" or ".log")
-        {
-            return _parseGcdumpReport(File.ReadAllText(inputPath));
-        }
-
-        WriteUnsupportedInput("Unsupported heap input", inputPath);
-        return null;
+        return _heapLoader.Load(inputPath);
     }
 
     public CpuProfileResult? AnalyzeCpuTrace(string traceFile)
     {
-        try
-        {
-            var result = _traceAnalyzer.AnalyzeCpuTrace(traceFile);
-            if (result.AllFunctions.Count == 0)
-            {
-                _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
-                return null;
-            }
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]CPU trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return _traceLoader.AnalyzeCpuTrace(traceFile);
     }
 
     public AllocationCallTreeResult? AnalyzeAllocationTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeAllocationTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Allocation trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return _traceLoader.AnalyzeAllocationTrace(traceFile);
     }
 
     public ExceptionProfileResult? AnalyzeExceptionTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeExceptionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Exception trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return _traceLoader.AnalyzeExceptionTrace(traceFile);
     }
 
     public ContentionProfileResult? AnalyzeContentionTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeContentionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Contention trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public static MemoryProfileResult BuildMemoryProfileResult(AllocationCallTreeResult callTree)
-    {
-        var allocationEntries = callTree.TypeRoots
-            .OrderByDescending(root => root.TotalBytes)
-            .Take(50)
-            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
-            .ToList();
-
-        var totalAllocated = FormatBytes(callTree.TotalBytes);
-
-        return new MemoryProfileResult(
-            null,
-            null,
-            null,
-            totalAllocated,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            totalAllocated,
-            allocationEntries,
-            callTree,
-            null,
-            null);
-    }
-
-    public static string BuildInputLabel(string inputPath)
-    {
-        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
-    }
-
-    public static void ApplyInputDefaults(
-        string inputPath,
-        ref bool runCpu,
-        ref bool runMemory,
-        ref bool runHeap,
-        ref bool runException,
-        ref bool runContention)
-    {
-        switch (GetNormalizedExtension(inputPath))
-        {
-            case ".json":
-                runCpu = true;
-                break;
-            case ".nettrace":
-                runCpu = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".etlx":
-                runMemory = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".gcdump":
-            case ".txt":
-            case ".log":
-                runHeap = true;
-                break;
-            default:
-                runCpu = true;
-                break;
-        }
-    }
-
-    private CpuProfileResult? AnalyzeSpeedscope(string speedscopePath)
-    {
-        try
-        {
-            return ProfilerTraceAnalyzer.AnalyzeSpeedscope(speedscopePath);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Speedscope parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    private bool TryValidateTraceInput(string inputPath, string unsupportedMessage)
-    {
-        if (!TryEnsureInputExists(inputPath))
-        {
-            return false;
-        }
-
-        if (IsSupportedExtension(GetNormalizedExtension(inputPath), ".nettrace", ".etlx"))
-        {
-            return true;
-        }
-
-        WriteUnsupportedInput(unsupportedMessage, inputPath);
-        return false;
-    }
-
-    private bool TryEnsureInputExists(string inputPath)
-    {
-        if (File.Exists(inputPath))
-        {
-            return true;
-        }
-
-        _writeLine($"[{_getTheme().ErrorColor}]Input file not found:[/] {Markup.Escape(inputPath)}");
-        return false;
-    }
-
-    private void WriteUnsupportedInput(string message, string inputPath)
-    {
-        _writeLine($"[{_getTheme().ErrorColor}]{message}:[/] {Markup.Escape(inputPath)}");
-    }
-
-    private static string GetNormalizedExtension(string inputPath)
-    {
-        return Path.GetExtension(inputPath).ToLowerInvariant();
-    }
-
-    private static bool IsSupportedExtension(string extension, params string[] allowedExtensions)
-    {
-        return allowedExtensions.Contains(extension, StringComparer.Ordinal);
+        return _traceLoader.AnalyzeContentionTrace(traceFile);
     }
 }

--- a/src/ProfileTool/ProfileMemoryResultFactory.cs
+++ b/src/ProfileTool/ProfileMemoryResultFactory.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using static Asynkron.Profiler.CallTreeHelpers;
+
+namespace Asynkron.Profiler;
+
+internal static class ProfileMemoryResultFactory
+{
+    public static MemoryProfileResult Build(AllocationCallTreeResult callTree)
+    {
+        var allocationEntries = callTree.TypeRoots
+            .OrderByDescending(root => root.TotalBytes)
+            .Take(50)
+            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
+            .ToList();
+
+        var totalAllocated = FormatBytes(callTree.TotalBytes);
+
+        return new MemoryProfileResult(
+            null,
+            null,
+            null,
+            totalAllocated,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            totalAllocated,
+            allocationEntries,
+            callTree,
+            null,
+            null);
+    }
+}

--- a/src/ProfileTool/ProfileTraceLoader.cs
+++ b/src/ProfileTool/ProfileTraceLoader.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfileTraceLoader
+{
+    private readonly ProfileInputDiagnostics _diagnostics;
+    private readonly ProfilerTraceAnalyzer _traceAnalyzer;
+    private readonly Func<Theme> _getTheme;
+    private readonly Action<string> _writeLine;
+
+    public ProfileTraceLoader(
+        ProfilerTraceAnalyzer traceAnalyzer,
+        Func<Theme> getTheme,
+        ProfileInputDiagnostics diagnostics,
+        Action<string> writeLine)
+    {
+        _diagnostics = diagnostics;
+        _traceAnalyzer = traceAnalyzer;
+        _getTheme = getTheme;
+        _writeLine = writeLine;
+    }
+
+    public CpuProfileResult? LoadCpu(string inputPath)
+    {
+        if (!TryEnsureInputExists(inputPath))
+        {
+            return null;
+        }
+
+        var extension = ProfileInputConventions.GetNormalizedExtension(inputPath);
+        if (extension == ".json")
+        {
+            return AnalyzeSpeedscope(inputPath);
+        }
+
+        if (!ProfileInputConventions.IsTraceExtension(extension))
+        {
+            _diagnostics.WriteUnsupportedInput("Unsupported CPU input", inputPath);
+            return null;
+        }
+
+        return AnalyzeCpuTrace(inputPath);
+    }
+
+    public MemoryProfileResult? LoadMemory(string inputPath)
+    {
+        if (!TryValidateTraceInput(inputPath, "Unsupported memory input"))
+        {
+            return null;
+        }
+
+        var callTree = AnalyzeAllocationTrace(inputPath);
+        return callTree == null ? null : ProfileMemoryResultFactory.Build(callTree);
+    }
+
+    public ExceptionProfileResult? LoadException(string inputPath)
+    {
+        if (!TryValidateTraceInput(inputPath, "Unsupported exception input"))
+        {
+            return null;
+        }
+
+        return AnalyzeExceptionTrace(inputPath);
+    }
+
+    public ContentionProfileResult? LoadContention(string inputPath)
+    {
+        if (!TryValidateTraceInput(inputPath, "Unsupported contention input"))
+        {
+            return null;
+        }
+
+        return AnalyzeContentionTrace(inputPath);
+    }
+
+    public CpuProfileResult? AnalyzeCpuTrace(string traceFile)
+    {
+        var result = ExecuteAnalysis("CPU trace parse failed", () => _traceAnalyzer.AnalyzeCpuTrace(traceFile));
+        if (result?.AllFunctions.Count == 0)
+        {
+            _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
+            return null;
+        }
+
+        return result;
+    }
+
+    public AllocationCallTreeResult? AnalyzeAllocationTrace(string traceFile)
+    {
+        return ExecuteAnalysis("Allocation trace parse failed", () => _traceAnalyzer.AnalyzeAllocationTrace(traceFile));
+    }
+
+    public ExceptionProfileResult? AnalyzeExceptionTrace(string traceFile)
+    {
+        return ExecuteAnalysis("Exception trace parse failed", () => _traceAnalyzer.AnalyzeExceptionTrace(traceFile));
+    }
+
+    public ContentionProfileResult? AnalyzeContentionTrace(string traceFile)
+    {
+        return ExecuteAnalysis("Contention trace parse failed", () => _traceAnalyzer.AnalyzeContentionTrace(traceFile));
+    }
+
+    private CpuProfileResult? AnalyzeSpeedscope(string speedscopePath)
+    {
+        return ExecuteAnalysis("Speedscope parse failed", () => ProfilerTraceAnalyzer.AnalyzeSpeedscope(speedscopePath));
+    }
+
+    private T? ExecuteAnalysis<T>(string failureLabel, Func<T> analyze)
+        where T : class
+    {
+        try
+        {
+            return analyze();
+        }
+        catch (Exception ex)
+        {
+            _writeLine($"[{_getTheme().AccentColor}]{failureLabel}:[/] {Markup.Escape(ex.Message)}");
+            return null;
+        }
+    }
+
+    private bool TryValidateTraceInput(string inputPath, string unsupportedMessage)
+    {
+        if (!TryEnsureInputExists(inputPath))
+        {
+            return false;
+        }
+
+        if (ProfileInputConventions.IsTraceExtension(ProfileInputConventions.GetNormalizedExtension(inputPath)))
+        {
+            return true;
+        }
+
+        _diagnostics.WriteUnsupportedInput(unsupportedMessage, inputPath);
+        return false;
+    }
+
+    private bool TryEnsureInputExists(string inputPath)
+    {
+        return _diagnostics.TryEnsureInputExists(inputPath);
+    }
+}

--- a/src/ProfileTool/ProfilerExecutionRequestFactory.cs
+++ b/src/ProfileTool/ProfilerExecutionRequestFactory.cs
@@ -37,13 +37,13 @@ internal sealed class ProfilerExecutionRequestFactory
 
         if (hasInput)
         {
-            label = ProfileInputLoader.BuildInputLabel(invocation.InputPath!);
+            label = ProfileInputConventions.BuildLabel(invocation.InputPath!);
             description = invocation.InputPath!;
             command = Array.Empty<string>();
 
             if (!hasExplicitModes)
             {
-                ProfileInputLoader.ApplyInputDefaults(
+                ProfileInputConventions.ApplyDefaults(
                     invocation.InputPath!,
                     ref runCpu,
                     ref runMemory,

--- a/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
@@ -31,7 +31,7 @@ public sealed class ProfileInputLoaderTests
             .ToArray();
         var callTree = new AllocationCallTreeResult(roots.Sum(root => root.TotalBytes), roots.Sum(root => root.Count), roots);
 
-        var result = ProfileInputLoader.BuildMemoryProfileResult(callTree);
+        var result = ProfileMemoryResultFactory.Build(callTree);
 
         Assert.Equal("1.50 KB", result.TotalAllocated);
         Assert.Equal("1.50 KB", result.AllocationTotal);
@@ -103,7 +103,7 @@ public sealed class ProfileInputLoaderTests
     [Fact]
     public void BuildInputLabel_FallsBackToInputWhenFileNameIsMissing()
     {
-        var label = ProfileInputLoader.BuildInputLabel(string.Empty);
+        var label = ProfileInputConventions.BuildLabel(string.Empty);
 
         Assert.Equal("input", label);
     }
@@ -122,7 +122,7 @@ public sealed class ProfileInputLoaderTests
         var runException = false;
         var runContention = false;
 
-        ProfileInputLoader.ApplyInputDefaults(
+        ProfileInputConventions.ApplyDefaults(
             inputPath,
             ref runCpu,
             ref runMemory,


### PR DESCRIPTION
﻿## Summary
- split `ProfileInputLoader` into smaller single-purpose collaborators for input conventions, shared diagnostics, trace loading, heap loading, and memory result creation
- updated `ProfileCollectionRunner` and `ProfilerExecutionRequestFactory` to use the extracted abstractions instead of reusing static helpers on the loader
- adjusted `ProfileInputLoaderTests` to cover the extracted conventions/factory behavior
- reran the pre-PR quality gate and kept the tree clean: build passes with 0 warnings, tests pass, and `quickdup` reports 0 duplicate patterns

## Testing
- `roslynator fix src/ProfileTool/ProfileTool.csproj`
- `roslynator fix src/ProfilerCore/Asynkron.Profiler.Core.csproj`
- `roslynator fix tests/Asynkron.Profiler.Tests/Asynkron.Profiler.Tests.csproj`
- `dotnet format Asynkron.Profiler.sln`
- `dotnet build Asynkron.Profiler.sln`
- `dotnet test Asynkron.Profiler.sln --no-build`
- `quickdup -path src -ext .cs -select 0..20 -min 2 -exclude ".g.,.generated."`