### PR TITLE
Refactor profile input handling for pre-PR readiness

### DIFF
--- a/src/ProfileTool/MemoryProfileResultFactory.cs
+++ b/src/ProfileTool/MemoryProfileResultFactory.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using static Asynkron.Profiler.CallTreeHelpers;
+
+namespace Asynkron.Profiler;
+
+internal static class MemoryProfileResultFactory
+{
+    public static MemoryProfileResult Create(AllocationCallTreeResult callTree)
+    {
+        var allocationEntries = callTree.TypeRoots
+            .OrderByDescending(root => root.TotalBytes)
+            .Take(50)
+            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
+            .ToList();
+
+        var totalAllocated = FormatBytes(callTree.TotalBytes);
+
+        return new MemoryProfileResult(
+            null,
+            null,
+            null,
+            totalAllocated,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            totalAllocated,
+            allocationEntries,
+            callTree,
+            null,
+            null);
+    }
+}

--- a/src/ProfileTool/ProfileCollectionRunner.cs
+++ b/src/ProfileTool/ProfileCollectionRunner.cs
@@ -17,7 +17,7 @@ internal sealed class ProfileCollectionRunner
     private readonly Func<Theme> _getTheme;
     private readonly Func<string, string, bool> _ensureToolAvailable;
     private readonly Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> _runProcess;
-    private readonly ProfileInputLoader _profileInputLoader;
+    private readonly ProfileTraceAnalysisRunner _analysisRunner;
     private readonly Action<string> _writeLine;
 
     public ProfileCollectionRunner(
@@ -25,14 +25,14 @@ internal sealed class ProfileCollectionRunner
         Func<Theme> getTheme,
         Func<string, string, bool> ensureToolAvailable,
         Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> runProcess,
-        ProfileInputLoader profileInputLoader,
+        ProfileTraceAnalysisRunner analysisRunner,
         Action<string> writeLine)
     {
         _outputDirectory = ArgumentGuard.RequireNotWhiteSpace(outputDirectory, nameof(outputDirectory), "Output directory is required.");
         _getTheme = getTheme;
         _ensureToolAvailable = ensureToolAvailable;
         _runProcess = runProcess;
-        _profileInputLoader = profileInputLoader;
+        _analysisRunner = analysisRunner;
         _writeLine = writeLine;
     }
 
@@ -109,7 +109,7 @@ internal sealed class ProfileCollectionRunner
                 collectArgs.Add("--providers");
                 collectArgs.Add("Microsoft-DotNETCore-SampleProfiler");
             },
-            _profileInputLoader.AnalyzeCpuTrace);
+            _analysisRunner.AnalyzeCpuTrace);
     }
 
     public MemoryProfileResult? RunMemoryProfile(string[] command, string label)
@@ -126,9 +126,9 @@ internal sealed class ProfileCollectionRunner
                 collectArgs.Add("--profile");
                 collectArgs.Add("gc-verbose");
             },
-            _profileInputLoader.AnalyzeAllocationTrace);
+            _analysisRunner.AnalyzeAllocationTrace);
 
-        return callTree == null ? null : ProfileInputLoader.BuildMemoryProfileResult(callTree);
+        return callTree == null ? null : MemoryProfileResultFactory.Create(callTree);
     }
 
     public ExceptionProfileResult? RunExceptionProfile(string[] command, string label)
@@ -146,7 +146,7 @@ internal sealed class ProfileCollectionRunner
                 collectArgs.Add("--providers");
                 collectArgs.Add(provider);
             },
-            _profileInputLoader.AnalyzeExceptionTrace);
+            _analysisRunner.AnalyzeExceptionTrace);
     }
 
     public ContentionProfileResult? RunContentionProfile(string[] command, string label)
@@ -167,7 +167,7 @@ internal sealed class ProfileCollectionRunner
                 collectArgs.Add("--providers");
                 collectArgs.Add(provider);
             },
-            _profileInputLoader.AnalyzeContentionTrace);
+            _analysisRunner.AnalyzeContentionTrace);
     }
 
     public HeapProfileResult? RunHeapProfile(string[] command, string label)

--- a/src/ProfileTool/ProfileInputConventions.cs
+++ b/src/ProfileTool/ProfileInputConventions.cs
@@ -1,0 +1,72 @@
+using System.IO;
+
+namespace Asynkron.Profiler;
+
+internal enum ProfileInputKind
+{
+    Unknown,
+    Speedscope,
+    NetTrace,
+    TraceLog,
+    GcDump,
+    HeapReport
+}
+
+internal static class ProfileInputConventions
+{
+    public static string BuildInputLabel(string inputPath)
+    {
+        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
+    }
+
+    public static void ApplyInputDefaults(
+        string inputPath,
+        ref bool runCpu,
+        ref bool runMemory,
+        ref bool runHeap,
+        ref bool runException,
+        ref bool runContention)
+    {
+        switch (Classify(inputPath))
+        {
+            case ProfileInputKind.Speedscope:
+                runCpu = true;
+                break;
+            case ProfileInputKind.NetTrace:
+                runCpu = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ProfileInputKind.TraceLog:
+                runMemory = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ProfileInputKind.GcDump:
+            case ProfileInputKind.HeapReport:
+                runHeap = true;
+                break;
+            default:
+                runCpu = true;
+                break;
+        }
+    }
+
+    public static ProfileInputKind Classify(string inputPath)
+    {
+        return GetNormalizedExtension(inputPath) switch
+        {
+            ".json" => ProfileInputKind.Speedscope,
+            ".nettrace" => ProfileInputKind.NetTrace,
+            ".etlx" => ProfileInputKind.TraceLog,
+            ".gcdump" => ProfileInputKind.GcDump,
+            ".txt" or ".log" => ProfileInputKind.HeapReport,
+            _ => ProfileInputKind.Unknown
+        };
+    }
+
+    private static string GetNormalizedExtension(string inputPath)
+    {
+        return Path.GetExtension(inputPath).ToLowerInvariant();
+    }
+}

--- a/src/ProfileTool/ProfileInputLoader.cs
+++ b/src/ProfileTool/ProfileInputLoader.cs
@@ -1,16 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using Spectre.Console;
-using static Asynkron.Profiler.CallTreeHelpers;
 
 namespace Asynkron.Profiler;
 
 internal sealed class ProfileInputLoader
 {
-    private readonly ProfilerTraceAnalyzer _traceAnalyzer;
+    private readonly ProfileTraceAnalysisRunner _analysisRunner;
     private readonly Func<Theme> _getTheme;
     private readonly Func<string, string, bool> _ensureToolAvailable;
     private readonly Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> _runProcess;
@@ -19,7 +15,7 @@ internal sealed class ProfileInputLoader
     private readonly string _dotnetGcdumpInstallHint;
 
     public ProfileInputLoader(
-        ProfilerTraceAnalyzer traceAnalyzer,
+        ProfileTraceAnalysisRunner analysisRunner,
         Func<Theme> getTheme,
         Func<string, string, bool> ensureToolAvailable,
         Func<string, IEnumerable<string>, string?, int, (bool Success, string StdOut, string StdErr)> runProcess,
@@ -27,7 +23,7 @@ internal sealed class ProfileInputLoader
         Action<string> writeLine,
         string dotnetGcdumpInstallHint)
     {
-        _traceAnalyzer = traceAnalyzer;
+        _analysisRunner = analysisRunner;
         _getTheme = getTheme;
         _ensureToolAvailable = ensureToolAvailable;
         _runProcess = runProcess;
@@ -43,19 +39,17 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".json")
+        switch (ProfileInputConventions.Classify(inputPath))
         {
-            return AnalyzeSpeedscope(inputPath);
+            case ProfileInputKind.Speedscope:
+                return _analysisRunner.AnalyzeSpeedscope(inputPath);
+            case ProfileInputKind.NetTrace:
+            case ProfileInputKind.TraceLog:
+                return _analysisRunner.AnalyzeCpuTrace(inputPath);
+            default:
+                WriteUnsupportedInput("Unsupported CPU input", inputPath);
+                return null;
         }
-
-        if (!IsSupportedExtension(extension, ".nettrace", ".etlx"))
-        {
-            WriteUnsupportedInput("Unsupported CPU input", inputPath);
-            return null;
-        }
-
-        return AnalyzeCpuTrace(inputPath);
     }
 
     public MemoryProfileResult? LoadMemory(string inputPath)
@@ -65,8 +59,8 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        var callTree = AnalyzeAllocationTrace(inputPath);
-        return callTree == null ? null : BuildMemoryProfileResult(callTree);
+        var callTree = _analysisRunner.AnalyzeAllocationTrace(inputPath);
+        return callTree == null ? null : MemoryProfileResultFactory.Create(callTree);
     }
 
     public ExceptionProfileResult? LoadException(string inputPath)
@@ -76,7 +70,7 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        return AnalyzeExceptionTrace(inputPath);
+        return _analysisRunner.AnalyzeExceptionTrace(inputPath);
     }
 
     public ContentionProfileResult? LoadContention(string inputPath)
@@ -86,7 +80,7 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        return AnalyzeContentionTrace(inputPath);
+        return _analysisRunner.AnalyzeContentionTrace(inputPath);
     }
 
     public HeapProfileResult? LoadHeap(string inputPath)
@@ -96,169 +90,25 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".gcdump")
+        switch (ProfileInputConventions.Classify(inputPath))
         {
-            if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
-            {
-                return null;
-            }
+            case ProfileInputKind.GcDump:
+                if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
+                {
+                    return null;
+                }
 
-            return GcdumpReportLoader.Load(
-                inputPath,
-                _getTheme(),
-                _runProcess,
-                _parseGcdumpReport,
-                _writeLine);
-        }
-
-        if (extension is ".txt" or ".log")
-        {
-            return _parseGcdumpReport(File.ReadAllText(inputPath));
-        }
-
-        WriteUnsupportedInput("Unsupported heap input", inputPath);
-        return null;
-    }
-
-    public CpuProfileResult? AnalyzeCpuTrace(string traceFile)
-    {
-        try
-        {
-            var result = _traceAnalyzer.AnalyzeCpuTrace(traceFile);
-            if (result.AllFunctions.Count == 0)
-            {
-                _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
-                return null;
-            }
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]CPU trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public AllocationCallTreeResult? AnalyzeAllocationTrace(string traceFile)
-    {
-        try
-        {
-            return _traceAnalyzer.AnalyzeAllocationTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Allocation trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public ExceptionProfileResult? AnalyzeExceptionTrace(string traceFile)
-    {
-        try
-        {
-            return _traceAnalyzer.AnalyzeExceptionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Exception trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public ContentionProfileResult? AnalyzeContentionTrace(string traceFile)
-    {
-        try
-        {
-            return _traceAnalyzer.AnalyzeContentionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Contention trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public static MemoryProfileResult BuildMemoryProfileResult(AllocationCallTreeResult callTree)
-    {
-        var allocationEntries = callTree.TypeRoots
-            .OrderByDescending(root => root.TotalBytes)
-            .Take(50)
-            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
-            .ToList();
-
-        var totalAllocated = FormatBytes(callTree.TotalBytes);
-
-        return new MemoryProfileResult(
-            null,
-            null,
-            null,
-            totalAllocated,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            totalAllocated,
-            allocationEntries,
-            callTree,
-            null,
-            null);
-    }
-
-    public static string BuildInputLabel(string inputPath)
-    {
-        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
-    }
-
-    public static void ApplyInputDefaults(
-        string inputPath,
-        ref bool runCpu,
-        ref bool runMemory,
-        ref bool runHeap,
-        ref bool runException,
-        ref bool runContention)
-    {
-        switch (GetNormalizedExtension(inputPath))
-        {
-            case ".json":
-                runCpu = true;
-                break;
-            case ".nettrace":
-                runCpu = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".etlx":
-                runMemory = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".gcdump":
-            case ".txt":
-            case ".log":
-                runHeap = true;
-                break;
+                return GcdumpReportLoader.Load(
+                    inputPath,
+                    _getTheme(),
+                    _runProcess,
+                    _parseGcdumpReport,
+                    _writeLine);
+            case ProfileInputKind.HeapReport:
+                return _parseGcdumpReport(File.ReadAllText(inputPath));
             default:
-                runCpu = true;
-                break;
-        }
-    }
-
-    private CpuProfileResult? AnalyzeSpeedscope(string speedscopePath)
-    {
-        try
-        {
-            return ProfilerTraceAnalyzer.AnalyzeSpeedscope(speedscopePath);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Speedscope parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
+                WriteUnsupportedInput("Unsupported heap input", inputPath);
+                return null;
         }
     }
 
@@ -269,7 +119,8 @@ internal sealed class ProfileInputLoader
             return false;
         }
 
-        if (IsSupportedExtension(GetNormalizedExtension(inputPath), ".nettrace", ".etlx"))
+        var inputKind = ProfileInputConventions.Classify(inputPath);
+        if (inputKind is ProfileInputKind.NetTrace or ProfileInputKind.TraceLog)
         {
             return true;
         }
@@ -285,22 +136,12 @@ internal sealed class ProfileInputLoader
             return true;
         }
 
-        _writeLine($"[{_getTheme().ErrorColor}]Input file not found:[/] {Markup.Escape(inputPath)}");
+        _writeLine($"[{_getTheme().ErrorColor}]Input file not found:[/] {Spectre.Console.Markup.Escape(inputPath)}");
         return false;
     }
 
     private void WriteUnsupportedInput(string message, string inputPath)
     {
-        _writeLine($"[{_getTheme().ErrorColor}]{message}:[/] {Markup.Escape(inputPath)}");
-    }
-
-    private static string GetNormalizedExtension(string inputPath)
-    {
-        return Path.GetExtension(inputPath).ToLowerInvariant();
-    }
-
-    private static bool IsSupportedExtension(string extension, params string[] allowedExtensions)
-    {
-        return allowedExtensions.Contains(extension, StringComparer.Ordinal);
+        _writeLine($"[{_getTheme().ErrorColor}]{message}:[/] {Spectre.Console.Markup.Escape(inputPath)}");
     }
 }

--- a/src/ProfileTool/ProfileTraceAnalysisRunner.cs
+++ b/src/ProfileTool/ProfileTraceAnalysisRunner.cs
@@ -1,0 +1,76 @@
+using System;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfileTraceAnalysisRunner
+{
+    private readonly Func<Theme> _getTheme;
+    private readonly ProfilerTraceAnalyzer _traceAnalyzer;
+    private readonly Action<string> _writeLine;
+
+    public ProfileTraceAnalysisRunner(
+        ProfilerTraceAnalyzer traceAnalyzer,
+        Func<Theme> getTheme,
+        Action<string> writeLine)
+    {
+        _traceAnalyzer = traceAnalyzer;
+        _getTheme = getTheme;
+        _writeLine = writeLine;
+    }
+
+    public CpuProfileResult? AnalyzeCpuTrace(string traceFile)
+    {
+        return Execute(
+            () => _traceAnalyzer.AnalyzeCpuTrace(traceFile),
+            "CPU trace parse failed",
+            result =>
+            {
+                if (result.AllFunctions.Count == 0)
+                {
+                    _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
+                    return null;
+                }
+
+                return result;
+            });
+    }
+
+    public AllocationCallTreeResult? AnalyzeAllocationTrace(string traceFile)
+    {
+        return Execute(() => _traceAnalyzer.AnalyzeAllocationTrace(traceFile), "Allocation trace parse failed");
+    }
+
+    public ExceptionProfileResult? AnalyzeExceptionTrace(string traceFile)
+    {
+        return Execute(() => _traceAnalyzer.AnalyzeExceptionTrace(traceFile), "Exception trace parse failed");
+    }
+
+    public ContentionProfileResult? AnalyzeContentionTrace(string traceFile)
+    {
+        return Execute(() => _traceAnalyzer.AnalyzeContentionTrace(traceFile), "Contention trace parse failed");
+    }
+
+    public CpuProfileResult? AnalyzeSpeedscope(string speedscopePath)
+    {
+        return Execute(() => ProfilerTraceAnalyzer.AnalyzeSpeedscope(speedscopePath), "Speedscope parse failed");
+    }
+
+    private TResult? Execute<TResult>(
+        Func<TResult> analyze,
+        string failureLabel,
+        Func<TResult, TResult?>? normalize = null)
+        where TResult : class
+    {
+        try
+        {
+            var result = analyze();
+            return normalize?.Invoke(result) ?? result;
+        }
+        catch (Exception ex)
+        {
+            _writeLine($"[{_getTheme().AccentColor}]{failureLabel}:[/] {Markup.Escape(ex.Message)}");
+            return null;
+        }
+    }
+}

--- a/src/ProfileTool/ProfilerCommandExecutor.cs
+++ b/src/ProfileTool/ProfilerCommandExecutor.cs
@@ -9,6 +9,7 @@ internal sealed class ProfilerCommandExecutor
     private readonly ProfileCollectionRunner _collectionRunner;
     private readonly string _outputDirectory;
     private readonly ProfileInputLoader _profileInputLoader;
+    private readonly ProfileTraceAnalysisRunner _traceAnalysisRunner;
     private readonly ProfilerExecutionRequestFactory _requestFactory;
     private readonly ProfilerToolAvailability _toolAvailability;
 
@@ -29,8 +30,9 @@ internal sealed class ProfilerCommandExecutor
         _toolAvailability = new ProfilerToolAvailability(() => _theme, ProcessRunner.Run, AnsiConsole.MarkupLine);
 
         var traceAnalyzer = new ProfilerTraceAnalyzer(_outputDirectory);
+        _traceAnalysisRunner = new ProfileTraceAnalysisRunner(traceAnalyzer, () => _theme, AnsiConsole.MarkupLine);
         _profileInputLoader = new ProfileInputLoader(
-            traceAnalyzer,
+            _traceAnalysisRunner,
             () => _theme,
             _toolAvailability.EnsureAvailable,
             ProcessRunner.Run,
@@ -42,7 +44,7 @@ internal sealed class ProfilerCommandExecutor
             () => _theme,
             _toolAvailability.EnsureAvailable,
             ProcessRunner.Run,
-            _profileInputLoader,
+            _traceAnalysisRunner,
             AnsiConsole.MarkupLine);
         _requestFactory = new ProfilerExecutionRequestFactory(() => _theme, ProcessRunner.Run);
     }
@@ -156,7 +158,7 @@ internal sealed class ProfilerCommandExecutor
         }
 
         return sharedTraceFile != null
-            ? _profileInputLoader.AnalyzeCpuTrace(sharedTraceFile)
+            ? _traceAnalysisRunner.AnalyzeCpuTrace(sharedTraceFile)
             : _collectionRunner.RunCpuProfile(request.Command, request.Label);
     }
 
@@ -180,7 +182,7 @@ internal sealed class ProfilerCommandExecutor
         }
 
         return sharedTraceFile != null
-            ? _profileInputLoader.LoadException(sharedTraceFile)
+            ? _traceAnalysisRunner.AnalyzeExceptionTrace(sharedTraceFile)
             : _collectionRunner.RunExceptionProfile(request.Command, request.Label);
     }
 

--- a/src/ProfileTool/ProfilerExecutionRequestFactory.cs
+++ b/src/ProfileTool/ProfilerExecutionRequestFactory.cs
@@ -37,13 +37,13 @@ internal sealed class ProfilerExecutionRequestFactory
 
         if (hasInput)
         {
-            label = ProfileInputLoader.BuildInputLabel(invocation.InputPath!);
+            label = ProfileInputConventions.BuildInputLabel(invocation.InputPath!);
             description = invocation.InputPath!;
             command = Array.Empty<string>();
 
             if (!hasExplicitModes)
             {
-                ProfileInputLoader.ApplyInputDefaults(
+                ProfileInputConventions.ApplyInputDefaults(
                     invocation.InputPath!,
                     ref runCpu,
                     ref runMemory,

--- a/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
@@ -31,7 +31,7 @@ public sealed class ProfileInputLoaderTests
             .ToArray();
         var callTree = new AllocationCallTreeResult(roots.Sum(root => root.TotalBytes), roots.Sum(root => root.Count), roots);
 
-        var result = ProfileInputLoader.BuildMemoryProfileResult(callTree);
+        var result = MemoryProfileResultFactory.Create(callTree);
 
         Assert.Equal("1.50 KB", result.TotalAllocated);
         Assert.Equal("1.50 KB", result.AllocationTotal);
@@ -103,9 +103,20 @@ public sealed class ProfileInputLoaderTests
     [Fact]
     public void BuildInputLabel_FallsBackToInputWhenFileNameIsMissing()
     {
-        var label = ProfileInputLoader.BuildInputLabel(string.Empty);
+        var label = ProfileInputConventions.BuildInputLabel(string.Empty);
 
         Assert.Equal("input", label);
+    }
+
+    [Fact]
+    public void Classify_MapsExtensionsToExpectedKinds()
+    {
+        Assert.Equal(ProfileInputKind.Speedscope, ProfileInputConventions.Classify("trace.json"));
+        Assert.Equal(ProfileInputKind.NetTrace, ProfileInputConventions.Classify("trace.nettrace"));
+        Assert.Equal(ProfileInputKind.TraceLog, ProfileInputConventions.Classify("trace.etlx"));
+        Assert.Equal(ProfileInputKind.GcDump, ProfileInputConventions.Classify("trace.gcdump"));
+        Assert.Equal(ProfileInputKind.HeapReport, ProfileInputConventions.Classify("trace.log"));
+        Assert.Equal(ProfileInputKind.Unknown, ProfileInputConventions.Classify("trace.bin"));
     }
 
     private static void AssertModes(
@@ -122,7 +133,7 @@ public sealed class ProfileInputLoaderTests
         var runException = false;
         var runContention = false;
 
-        ProfileInputLoader.ApplyInputDefaults(
+        ProfileInputConventions.ApplyInputDefaults(
             inputPath,
             ref runCpu,
             ref runMemory,
@@ -147,7 +158,7 @@ public sealed class ProfileInputLoaderTests
         Directory.CreateDirectory(outputDir);
 
         return new ProfileInputLoader(
-            new ProfilerTraceAnalyzer(outputDir),
+            new ProfileTraceAnalysisRunner(new ProfilerTraceAnalyzer(outputDir), () => Theme.Current, message => messages?.Add(message)),
             () => Theme.Current,
             ensureToolAvailable,
             runProcess ?? ((_, _, _, _) => (true, string.Empty, string.Empty)),


### PR DESCRIPTION
﻿## Summary
- split `ProfileInputLoader` responsibilities into dedicated `ProfileInputConventions`, `ProfileTraceAnalysisRunner`, and `MemoryProfileResultFactory` types
- updated command execution and trace collection to depend on the extracted services instead of the monolithic loader
- expanded tests to cover input classification and the moved memory result shaping logic
- left the branch in a warning-free, duplication-free, ready-for-PR state

## Testing
- `dotnet build Asynkron.Profiler.sln -warnaserror`
- `dotnet test Asynkron.Profiler.sln --no-build`
- `dotnet format analyzers Asynkron.Profiler.sln --verify-no-changes`
- `dotnet format style Asynkron.Profiler.sln --verify-no-changes`
- `quickdup -path src -ext .cs -select 0..20 -min 2 -exclude '.g.,.generated.'`

## Notes
- I attempted the `pre-pr` skill's `roslynator fix Asynkron.Profiler.sln` step first, but the installed global Roslynator CLI crashes against the local SDK/MSBuild toolchain with a `MissingFieldException` on `MSBuildConstants.InvalidPathChars`. I used `dotnet format` analyzer/style verification plus a warning-as-error build to cover the same readiness gate for this branch.