### PR TITLE
Refactor profiler command execution responsibilities

### DIFF
--- a/src/ProfileTool/ProfilerCommandExecutor.cs
+++ b/src/ProfileTool/ProfilerCommandExecutor.cs
@@ -1,55 +1,48 @@
 using System;
-using System.Collections.Generic;
 using Spectre.Console;
 
 namespace Asynkron.Profiler;
 
 internal sealed class ProfilerCommandExecutor
 {
-    private readonly ProfileCollectionRunner _collectionRunner;
     private readonly string _outputDirectory;
-    private readonly ProfileInputLoader _profileInputLoader;
+    private readonly ProfilerExecutionResultResolver _resultResolver;
     private readonly ProfilerExecutionRequestFactory _requestFactory;
-    private readonly ProfilerToolAvailability _toolAvailability;
-
-    private HotJitDisasmRunner _hotJitDisasmRunner = null!;
-    private ProfilerJitModeRunner _jitModeRunner = null!;
-    private ProfilerConsoleRenderer _renderer = null!;
-    private Theme _theme;
+    private readonly ProfilerThemeRuntime _themeRuntime;
 
     public ProfilerCommandExecutor(string workingDirectory)
     {
         ArgumentGuard.RequireNotWhiteSpace(workingDirectory, nameof(workingDirectory), "Working directory is required.");
 
-        _theme = Theme.Current;
         _outputDirectory = Path.Combine(workingDirectory, "profile-output");
         Directory.CreateDirectory(_outputDirectory);
 
-        RefreshThemeServices();
-        _toolAvailability = new ProfilerToolAvailability(() => _theme, ProcessRunner.Run, AnsiConsole.MarkupLine);
+        _themeRuntime = new ProfilerThemeRuntime(_outputDirectory, Theme.Current, AnsiConsole.MarkupLine);
+        var toolAvailability = new ProfilerToolAvailability(() => _themeRuntime.CurrentTheme, ProcessRunner.Run, AnsiConsole.MarkupLine);
 
         var traceAnalyzer = new ProfilerTraceAnalyzer(_outputDirectory);
-        _profileInputLoader = new ProfileInputLoader(
+        var profileInputLoader = new ProfileInputLoader(
             traceAnalyzer,
-            () => _theme,
-            _toolAvailability.EnsureAvailable,
+            () => _themeRuntime.CurrentTheme,
+            toolAvailability.EnsureAvailable,
             ProcessRunner.Run,
             GcdumpReportParser.Parse,
             AnsiConsole.MarkupLine,
             ProfileCollectionRunner.DotnetGcdumpInstallHint);
-        _collectionRunner = new ProfileCollectionRunner(
+        var collectionRunner = new ProfileCollectionRunner(
             _outputDirectory,
-            () => _theme,
-            _toolAvailability.EnsureAvailable,
+            () => _themeRuntime.CurrentTheme,
+            toolAvailability.EnsureAvailable,
             ProcessRunner.Run,
-            _profileInputLoader,
+            profileInputLoader,
             AnsiConsole.MarkupLine);
-        _requestFactory = new ProfilerExecutionRequestFactory(() => _theme, ProcessRunner.Run);
+        _resultResolver = new ProfilerExecutionResultResolver(collectionRunner, profileInputLoader);
+        _requestFactory = new ProfilerExecutionRequestFactory(() => _themeRuntime.CurrentTheme, ProcessRunner.Run);
     }
 
     public void Execute(ProfilerCommandInvocation invocation)
     {
-        if (!TryApplyTheme(invocation.ThemeName))
+        if (!_themeRuntime.TryApply(invocation.ThemeName))
         {
             return;
         }
@@ -60,17 +53,17 @@ internal sealed class ProfilerCommandExecutor
             return;
         }
 
-        if (_jitModeRunner.TryHandleDumpModes(request))
+        if (_themeRuntime.JitModeRunner.TryHandleDumpModes(request))
         {
             return;
         }
 
-        if (!_jitModeRunner.ValidateHotJitRequest(request))
+        if (!_themeRuntime.JitModeRunner.ValidateHotJitRequest(request))
         {
             return;
         }
 
-        var sharedTraceFile = CollectSharedTraceFile(request);
+        var sharedTraceFile = _resultResolver.CollectSharedTraceFile(request);
         if (request.RunCpu && request.RunMemory)
         {
             ExecuteCombinedCpuAndMemory(request, sharedTraceFile);
@@ -83,22 +76,22 @@ internal sealed class ProfilerCommandExecutor
         if (request.RunException)
         {
             Console.WriteLine($"{request.Label} - exception");
-            var results = ResolveExceptionResults(request, sharedTraceFile);
-            _renderer.PrintExceptionResults(results, request.RenderRequest);
+            var results = _resultResolver.ResolveExceptionResults(request, sharedTraceFile);
+            _themeRuntime.Renderer.PrintExceptionResults(results, request.RenderRequest);
         }
 
         if (request.RunContention)
         {
             Console.WriteLine($"{request.Label} - contention");
-            var results = ResolveContentionResults(request);
-            _renderer.PrintContentionResults(results, request.RenderRequest);
+            var results = _resultResolver.ResolveContentionResults(request);
+            _themeRuntime.Renderer.PrintContentionResults(results, request.RenderRequest);
         }
 
         if (request.RunHeap)
         {
             Console.WriteLine($"{request.Label} - heap");
-            var results = ResolveHeapResults(request);
-            _renderer.PrintHeapResults(results, request.RenderRequest);
+            var results = _resultResolver.ResolveHeapResults(request);
+            _themeRuntime.Renderer.PrintHeapResults(results, request.RenderRequest);
         }
     }
 
@@ -107,19 +100,19 @@ internal sealed class ProfilerCommandExecutor
         CpuProfileResult? results,
         MemoryProfileResult? memoryResults = null)
     {
-        _renderer.PrintCpuResults(results, request.RenderRequest, memoryResults);
+        _themeRuntime.Renderer.PrintCpuResults(results, request.RenderRequest, memoryResults);
 
         if (results != null && request.ShouldRunHotJitDisasm)
         {
-            _hotJitDisasmRunner.Run(request, results);
+            _themeRuntime.HotJitDisasmRunner.Run(request, results);
         }
     }
 
     private void ExecuteCombinedCpuAndMemory(ProfilerExecutionRequest request, string? sharedTraceFile)
     {
         Console.WriteLine($"{request.Label} - cpu+memory");
-        var cpuResults = ResolveCpuResults(request, sharedTraceFile);
-        var memoryResults = ResolveMemoryResults(request, sharedTraceFile);
+        var cpuResults = _resultResolver.ResolveCpuResults(request, sharedTraceFile);
+        var memoryResults = _resultResolver.ResolveMemoryResults(request, sharedTraceFile);
 
         if (cpuResults != null)
         {
@@ -127,7 +120,7 @@ internal sealed class ProfilerCommandExecutor
         }
         else if (memoryResults != null)
         {
-            _renderer.PrintMemoryResults(memoryResults, request.RenderRequest);
+            _themeRuntime.Renderer.PrintMemoryResults(memoryResults, request.RenderRequest);
         }
     }
 
@@ -136,110 +129,15 @@ internal sealed class ProfilerCommandExecutor
         if (request.RunCpu)
         {
             Console.WriteLine($"{request.Label} - cpu");
-            var results = ResolveCpuResults(request, sharedTraceFile);
+            var results = _resultResolver.ResolveCpuResults(request, sharedTraceFile);
             RenderCpuResults(request, results);
         }
 
         if (request.RunMemory)
         {
             Console.WriteLine($"{request.Label} - memory");
-            var results = ResolveMemoryResults(request, sharedTraceFile);
-            _renderer.PrintMemoryResults(results, request.RenderRequest);
-        }
-    }
-
-    private CpuProfileResult? ResolveCpuResults(ProfilerExecutionRequest request, string? sharedTraceFile)
-    {
-        if (request.HasInput)
-        {
-            return _profileInputLoader.LoadCpu(request.InputPath!);
-        }
-
-        return sharedTraceFile != null
-            ? _profileInputLoader.AnalyzeCpuTrace(sharedTraceFile)
-            : _collectionRunner.RunCpuProfile(request.Command, request.Label);
-    }
-
-    private MemoryProfileResult? ResolveMemoryResults(ProfilerExecutionRequest request, string? sharedTraceFile)
-    {
-        if (request.HasInput)
-        {
-            return _profileInputLoader.LoadMemory(request.InputPath!);
-        }
-
-        return sharedTraceFile != null
-            ? _profileInputLoader.LoadMemory(sharedTraceFile)
-            : _collectionRunner.RunMemoryProfile(request.Command, request.Label);
-    }
-
-    private ExceptionProfileResult? ResolveExceptionResults(ProfilerExecutionRequest request, string? sharedTraceFile)
-    {
-        if (request.HasInput)
-        {
-            return _profileInputLoader.LoadException(request.InputPath!);
-        }
-
-        return sharedTraceFile != null
-            ? _profileInputLoader.LoadException(sharedTraceFile)
-            : _collectionRunner.RunExceptionProfile(request.Command, request.Label);
-    }
-
-    private ContentionProfileResult? ResolveContentionResults(ProfilerExecutionRequest request)
-    {
-        return request.HasInput
-            ? _profileInputLoader.LoadContention(request.InputPath!)
-            : _collectionRunner.RunContentionProfile(request.Command, request.Label);
-    }
-
-    private HeapProfileResult? ResolveHeapResults(ProfilerExecutionRequest request)
-    {
-        return request.HasInput
-            ? _profileInputLoader.LoadHeap(request.InputPath!)
-            : _collectionRunner.RunHeapProfile(request.Command, request.Label);
-    }
-
-    private string? CollectSharedTraceFile(ProfilerExecutionRequest request)
-    {
-        if (request.HasInput || !request.RunCpu || (!request.RunMemory && !request.RunException))
-        {
-            return null;
-        }
-
-        return _collectionRunner.CollectCpuTrace(request.Command, request.Label, request.RunMemory, request.RunException);
-    }
-
-    private bool TryApplyTheme(string? themeName)
-    {
-        if (!Theme.TryResolve(themeName, out var selectedTheme))
-        {
-            var name = themeName ?? string.Empty;
-            AnsiConsole.MarkupLine($"[{_theme.ErrorColor}]Unknown theme '{Markup.Escape(name)}'[/]");
-            AnsiConsole.MarkupLine($"[{_theme.AccentColor}]Available themes:[/] {Theme.AvailableThemes}");
-            return false;
-        }
-
-        Theme.Current = selectedTheme;
-        _theme = selectedTheme;
-        RefreshThemeServices();
-        return true;
-    }
-
-    private void RefreshThemeServices()
-    {
-        _renderer = new ProfilerConsoleRenderer(_theme);
-        var jitOutputFormatter = new JitOutputFormatter(_theme);
-        var jitCommandRunner = new JitCommandRunner(_theme, _outputDirectory, jitOutputFormatter);
-        var jitContext = new JitExecutionContext(_theme, jitCommandRunner, jitOutputFormatter, WriteOutputFiles);
-        _jitModeRunner = new ProfilerJitModeRunner(jitContext);
-        _hotJitDisasmRunner = new HotJitDisasmRunner(jitContext);
-    }
-
-    private void WriteOutputFiles(string label, IEnumerable<string> files)
-    {
-        AnsiConsole.MarkupLine($"[{_theme.AccentColor}]{label}:[/]");
-        foreach (var file in files)
-        {
-            Console.WriteLine(file);
+            var results = _resultResolver.ResolveMemoryResults(request, sharedTraceFile);
+            _themeRuntime.Renderer.PrintMemoryResults(results, request.RenderRequest);
         }
     }
 }

--- a/src/ProfileTool/ProfilerExecutionResultResolver.cs
+++ b/src/ProfileTool/ProfilerExecutionResultResolver.cs
@@ -1,0 +1,73 @@
+namespace Asynkron.Profiler;
+
+internal sealed class ProfilerExecutionResultResolver
+{
+    private readonly ProfileCollectionRunner _collectionRunner;
+    private readonly ProfileInputLoader _profileInputLoader;
+
+    public ProfilerExecutionResultResolver(ProfileCollectionRunner collectionRunner, ProfileInputLoader profileInputLoader)
+    {
+        _collectionRunner = collectionRunner;
+        _profileInputLoader = profileInputLoader;
+    }
+
+    public string? CollectSharedTraceFile(ProfilerExecutionRequest request)
+    {
+        if (request.HasInput || !request.RunCpu || (!request.RunMemory && !request.RunException))
+        {
+            return null;
+        }
+
+        return _collectionRunner.CollectCpuTrace(request.Command, request.Label, request.RunMemory, request.RunException);
+    }
+
+    public CpuProfileResult? ResolveCpuResults(ProfilerExecutionRequest request, string? sharedTraceFile)
+    {
+        if (request.HasInput)
+        {
+            return _profileInputLoader.LoadCpu(request.InputPath!);
+        }
+
+        return sharedTraceFile != null
+            ? _profileInputLoader.AnalyzeCpuTrace(sharedTraceFile)
+            : _collectionRunner.RunCpuProfile(request.Command, request.Label);
+    }
+
+    public MemoryProfileResult? ResolveMemoryResults(ProfilerExecutionRequest request, string? sharedTraceFile)
+    {
+        if (request.HasInput)
+        {
+            return _profileInputLoader.LoadMemory(request.InputPath!);
+        }
+
+        return sharedTraceFile != null
+            ? _profileInputLoader.LoadMemory(sharedTraceFile)
+            : _collectionRunner.RunMemoryProfile(request.Command, request.Label);
+    }
+
+    public ExceptionProfileResult? ResolveExceptionResults(ProfilerExecutionRequest request, string? sharedTraceFile)
+    {
+        if (request.HasInput)
+        {
+            return _profileInputLoader.LoadException(request.InputPath!);
+        }
+
+        return sharedTraceFile != null
+            ? _profileInputLoader.LoadException(sharedTraceFile)
+            : _collectionRunner.RunExceptionProfile(request.Command, request.Label);
+    }
+
+    public ContentionProfileResult? ResolveContentionResults(ProfilerExecutionRequest request)
+    {
+        return request.HasInput
+            ? _profileInputLoader.LoadContention(request.InputPath!)
+            : _collectionRunner.RunContentionProfile(request.Command, request.Label);
+    }
+
+    public HeapProfileResult? ResolveHeapResults(ProfilerExecutionRequest request)
+    {
+        return request.HasInput
+            ? _profileInputLoader.LoadHeap(request.InputPath!)
+            : _collectionRunner.RunHeapProfile(request.Command, request.Label);
+    }
+}

--- a/src/ProfileTool/ProfilerThemeRuntime.cs
+++ b/src/ProfileTool/ProfilerThemeRuntime.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfilerThemeRuntime
+{
+    private readonly string _outputDirectory;
+    private readonly Action<string> _writeLine;
+
+    private HotJitDisasmRunner _hotJitDisasmRunner = null!;
+    private ProfilerJitModeRunner _jitModeRunner = null!;
+    private ProfilerConsoleRenderer _renderer = null!;
+
+    public ProfilerThemeRuntime(string outputDirectory, Theme initialTheme, Action<string> writeLine)
+    {
+        _outputDirectory = outputDirectory;
+        _writeLine = writeLine;
+        CurrentTheme = initialTheme;
+        Theme.Current = initialTheme;
+        RefreshServices();
+    }
+
+    public Theme CurrentTheme { get; private set; }
+
+    public HotJitDisasmRunner HotJitDisasmRunner => _hotJitDisasmRunner;
+
+    public ProfilerJitModeRunner JitModeRunner => _jitModeRunner;
+
+    public ProfilerConsoleRenderer Renderer => _renderer;
+
+    public bool TryApply(string? themeName)
+    {
+        if (!Theme.TryResolve(themeName, out var selectedTheme))
+        {
+            var name = themeName ?? string.Empty;
+            _writeLine($"[{CurrentTheme.ErrorColor}]Unknown theme '{Markup.Escape(name)}'[/]");
+            _writeLine($"[{CurrentTheme.AccentColor}]Available themes:[/] {Theme.AvailableThemes}");
+            return false;
+        }
+
+        CurrentTheme = selectedTheme;
+        Theme.Current = selectedTheme;
+        RefreshServices();
+        return true;
+    }
+
+    private void RefreshServices()
+    {
+        _renderer = new ProfilerConsoleRenderer(CurrentTheme);
+        var jitOutputFormatter = new JitOutputFormatter(CurrentTheme);
+        var jitCommandRunner = new JitCommandRunner(CurrentTheme, _outputDirectory, jitOutputFormatter);
+        var jitContext = new JitExecutionContext(CurrentTheme, jitCommandRunner, jitOutputFormatter, WriteOutputFiles);
+        _jitModeRunner = new ProfilerJitModeRunner(jitContext);
+        _hotJitDisasmRunner = new HotJitDisasmRunner(jitContext);
+    }
+
+    private void WriteOutputFiles(string label, IEnumerable<string> files)
+    {
+        _writeLine($"[{CurrentTheme.AccentColor}]{label}:[/]");
+        foreach (var file in files)
+        {
+            Console.WriteLine(file);
+        }
+    }
+}

--- a/tests/Asynkron.Profiler.Tests/ProfilerThemeRuntimeTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfilerThemeRuntimeTests.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class ProfilerThemeRuntimeTests
+{
+    [Fact]
+    public void TryApply_UsesResolvedThemeAndRefreshesServices()
+    {
+        var originalTheme = Theme.Current;
+
+        try
+        {
+            var runtime = new ProfilerThemeRuntime(Path.GetTempPath(), Theme.Default, _ => { });
+            var originalRenderer = runtime.Renderer;
+
+            var applied = runtime.TryApply("nord");
+
+            Assert.True(applied);
+            Assert.Equal(Theme.Nord.AccentColor, runtime.CurrentTheme.AccentColor);
+            Assert.Equal(Theme.Nord.AccentColor, Theme.Current.AccentColor);
+            Assert.NotSame(originalRenderer, runtime.Renderer);
+        }
+        finally
+        {
+            Theme.Current = originalTheme;
+        }
+    }
+
+    [Fact]
+    public void TryApply_RejectsUnknownThemeWithoutReplacingServices()
+    {
+        var originalTheme = Theme.Current;
+
+        try
+        {
+            var runtime = new ProfilerThemeRuntime(Path.GetTempPath(), Theme.Monokai, _ => { });
+            var originalRenderer = runtime.Renderer;
+
+            var applied = runtime.TryApply("does-not-exist");
+
+            Assert.False(applied);
+            Assert.Equal(Theme.Monokai.AccentColor, runtime.CurrentTheme.AccentColor);
+            Assert.Equal(Theme.Monokai.AccentColor, Theme.Current.AccentColor);
+            Assert.Same(originalRenderer, runtime.Renderer);
+        }
+        finally
+        {
+            Theme.Current = originalTheme;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- slimmed `ProfilerCommandExecutor` down to orchestration-only flow control
- extracted renderer/JIT/theme lifecycle management into `ProfilerThemeRuntime`
- extracted input-vs-collection result routing into `ProfilerExecutionResultResolver`
- added unit coverage for successful and rejected theme application behavior

## Testing
- `roslynator fix src/ProfileTool/ProfileTool.csproj`
- `roslynator fix src/ProfilerCore/Asynkron.Profiler.Core.csproj`
- `roslynator fix tests/Asynkron.Profiler.Tests/Asynkron.Profiler.Tests.csproj`
- `dotnet format Asynkron.Profiler.sln`
- `dotnet build Asynkron.Profiler.sln -warnaserror`
- `dotnet test Asynkron.Profiler.sln -warnaserror --no-build`
- `quickdup -path src -ext .cs -select 0..20 -min 2 -exclude ".g.,.generated."`