### PR TITLE
Refactor name formatting and speedscope parsing

### DIFF
--- a/src/ProfileTool/Cpu/SpeedscopeAggregationState.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeAggregationState.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Asynkron.Profiler;
+
+internal sealed class SpeedscopeAggregationState
+{
+    private const string UnknownFrameName = "Unknown";
+
+    private readonly IReadOnlyList<string> _frames;
+    private readonly Dictionary<int, double> _frameTimes = new();
+    private readonly Dictionary<int, int> _frameCounts = new();
+
+    public SpeedscopeAggregationState(IReadOnlyList<string> frames)
+    {
+        _frames = frames;
+    }
+
+    public CallTreeNode Root { get; } = CallTreeNode.CreateRoot();
+
+    public double CallTreeTotal { get; private set; }
+
+    private bool HasSampledProfile { get; set; }
+
+    private bool HasSampleUnit { get; set; }
+
+    private bool HasTimeUnit { get; set; }
+
+    private int ParsedProfiles { get; set; }
+
+    public void RegisterEventedProfile()
+    {
+        ParsedProfiles++;
+        HasTimeUnit = true;
+    }
+
+    public void RegisterSampledProfile(bool isSampleUnit)
+    {
+        ParsedProfiles++;
+        HasSampledProfile = true;
+        if (isSampleUnit)
+        {
+            HasSampleUnit = true;
+        }
+        else
+        {
+            HasTimeUnit = true;
+        }
+    }
+
+    public CallTreeNode GetOrCreateChild(CallTreeNode parent, int frameIdx)
+    {
+        if (!parent.Children.TryGetValue(frameIdx, out var child))
+        {
+            child = new CallTreeNode(frameIdx, GetFrameName(frameIdx));
+            parent.Children[frameIdx] = child;
+        }
+
+        return child;
+    }
+
+    public void AddFrameTime(int frameIdx, double duration)
+    {
+        _frameTimes.TryGetValue(frameIdx, out var time);
+        _frameTimes[frameIdx] = time + duration;
+    }
+
+    public void AddFrameCalls(int frameIdx, int calls)
+    {
+        _frameCounts.TryGetValue(frameIdx, out var currentCalls);
+        _frameCounts[frameIdx] = currentCalls + calls;
+    }
+
+    public void AddRootDuration(double duration)
+    {
+        CallTreeTotal += duration;
+    }
+
+    public CpuProfileResult? BuildResult(string? speedscopePath)
+    {
+        if (ParsedProfiles == 0)
+        {
+            return null;
+        }
+
+        var totalTime = _frameTimes.Values.Sum();
+        FinalizeRoot();
+
+        var allFunctions = _frameTimes
+            .OrderByDescending(kv => kv.Value)
+            .Select(kv =>
+            {
+                _frameCounts.TryGetValue(kv.Key, out var calls);
+                return new FunctionSample(GetFrameName(kv.Key), kv.Value, calls, kv.Key);
+            })
+            .ToList();
+
+        var timeUnitLabel = HasSampleUnit && !HasTimeUnit ? "samples" : "ms";
+        var countLabel = HasSampledProfile ? "Samples" : "Calls";
+        var countSuffix = HasSampledProfile ? " samp" : "x";
+
+        return new CpuProfileResult(
+            allFunctions,
+            totalTime,
+            Root,
+            CallTreeTotal,
+            speedscopePath,
+            timeUnitLabel,
+            countLabel,
+            countSuffix);
+    }
+
+    private string GetFrameName(int frameIdx)
+    {
+        return frameIdx >= 0 && frameIdx < _frames.Count
+            ? _frames[frameIdx]
+            : UnknownFrameName;
+    }
+
+    private void FinalizeRoot()
+    {
+        if (CallTreeTotal <= 0)
+        {
+            CallTreeTotal = SumCallTreeTotals(Root);
+        }
+
+        Root.Total = CallTreeTotal;
+        Root.Calls = SumCallTreeCalls(Root);
+
+        foreach (var child in Root.Children.Values)
+        {
+            if (child.HasTiming)
+            {
+                Root.UpdateTiming(child.MinStart, child.MaxEnd);
+            }
+        }
+    }
+
+    private static double SumCallTreeTotals(CallTreeNode node)
+    {
+        var sum = 0d;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Total;
+        }
+
+        return sum;
+    }
+
+    private static int SumCallTreeCalls(CallTreeNode node)
+    {
+        var sum = 0;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Calls;
+        }
+
+        return sum;
+    }
+}

--- a/src/ProfileTool/Cpu/SpeedscopeDocumentReader.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeDocumentReader.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal static class SpeedscopeDocumentReader
+{
+    public static bool TryRead(JsonDocument doc, out SpeedscopeDocument speedscopeDocument)
+    {
+        speedscopeDocument = default;
+
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("shared", out var shared) ||
+            !shared.TryGetProperty("frames", out var framesElement) ||
+            framesElement.ValueKind != JsonValueKind.Array ||
+            !root.TryGetProperty("profiles", out var profilesElement) ||
+            profilesElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var frames = new List<string>();
+        foreach (var frame in framesElement.EnumerateArray())
+        {
+            var name = frame.TryGetProperty("name", out var nameElement)
+                ? nameElement.GetString()
+                : null;
+            frames.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
+        }
+
+        speedscopeDocument = new SpeedscopeDocument(frames, profilesElement);
+        return true;
+    }
+
+    public static JsonElement? ReadWeights(JsonElement profile)
+    {
+        if (profile.TryGetProperty("weights", out var weightsElement) &&
+            weightsElement.ValueKind == JsonValueKind.Array)
+        {
+            return weightsElement;
+        }
+
+        return null;
+    }
+}
+
+internal readonly record struct SpeedscopeDocument(IReadOnlyList<string> Frames, JsonElement Profiles);

--- a/src/ProfileTool/Cpu/SpeedscopeEventedProfileProcessor.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeEventedProfileProcessor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal static class SpeedscopeEventedProfileProcessor
+{
+    public static void Process(JsonElement eventsElement, SpeedscopeAggregationState state, double timeScale)
+    {
+        var stack = new List<FrameActivation>();
+        var hasLastTimestamp = false;
+        var lastTimestamp = 0d;
+
+        foreach (var evt in eventsElement.EnumerateArray())
+        {
+            if (!TryReadEvent(evt, timeScale, out var eventType, out var frameIdx, out var timestamp))
+            {
+                continue;
+            }
+
+            if (hasLastTimestamp && stack.Count > 0)
+            {
+                stack[^1].Node.Self += timestamp - lastTimestamp;
+            }
+
+            hasLastTimestamp = true;
+            lastTimestamp = timestamp;
+
+            if (string.Equals(eventType, "O", StringComparison.Ordinal))
+            {
+                var parentNode = stack.Count > 0 ? stack[^1].Node : state.Root;
+                var childNode = state.GetOrCreateChild(parentNode, frameIdx);
+                childNode.IncrementCalls();
+                state.AddFrameCalls(frameIdx, 1);
+                stack.Add(new FrameActivation(childNode, timestamp, frameIdx));
+            }
+            else if (string.Equals(eventType, "C", StringComparison.Ordinal) &&
+                     stack.Count > 0 &&
+                     stack[^1].FrameIdx == frameIdx)
+            {
+                var (node, openTimestamp, _) = stack[^1];
+                stack.RemoveAt(stack.Count - 1);
+
+                var duration = timestamp - openTimestamp;
+                state.AddFrameTime(frameIdx, duration);
+                node.Total += duration;
+                node.UpdateTiming(openTimestamp, timestamp);
+
+                if (stack.Count == 0)
+                {
+                    state.AddRootDuration(duration);
+                }
+            }
+        }
+    }
+
+    private static bool TryReadEvent(
+        JsonElement evt,
+        double timeScale,
+        out string? eventType,
+        out int frameIdx,
+        out double timestamp)
+    {
+        eventType = null;
+        frameIdx = default;
+        timestamp = default;
+
+        if (!evt.TryGetProperty("type", out var typeElement) ||
+            typeElement.ValueKind != JsonValueKind.String ||
+            !evt.TryGetProperty("frame", out var frameElement) ||
+            frameElement.ValueKind != JsonValueKind.Number ||
+            !evt.TryGetProperty("at", out var atElement) ||
+            atElement.ValueKind != JsonValueKind.Number)
+        {
+            return false;
+        }
+
+        eventType = typeElement.GetString();
+        frameIdx = frameElement.GetInt32();
+        timestamp = atElement.GetDouble() * timeScale;
+        return true;
+    }
+
+    private readonly record struct FrameActivation(CallTreeNode Node, double StartTime, int FrameIdx);
+}

--- a/src/ProfileTool/Cpu/SpeedscopeParser.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeParser.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace Asynkron.Profiler;
@@ -22,350 +20,37 @@ public static class SpeedscopeParser
 
     private static CpuProfileResult? ParseDocument(JsonDocument doc, string? speedscopePath)
     {
-        var root = doc.RootElement;
-        if (!root.TryGetProperty("shared", out var shared) ||
-            !shared.TryGetProperty("frames", out var framesElement) ||
-            framesElement.ValueKind != JsonValueKind.Array)
+        if (!SpeedscopeDocumentReader.TryRead(doc, out var speedscopeDocument))
         {
             return null;
         }
 
-        if (!root.TryGetProperty("profiles", out var profilesElement) ||
-            profilesElement.ValueKind != JsonValueKind.Array)
+        var state = new SpeedscopeAggregationState(speedscopeDocument.Frames);
+        foreach (var profile in speedscopeDocument.Profiles.EnumerateArray())
         {
-            return null;
-        }
-
-        var framesList = new List<string>();
-        foreach (var frame in framesElement.EnumerateArray())
-        {
-            var name = frame.TryGetProperty("name", out var nameElement)
-                ? nameElement.GetString()
-                : null;
-            framesList.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
-        }
-
-        var frameTimes = new Dictionary<int, double>();
-        var frameSelfTimes = new Dictionary<int, double>();
-        var frameCounts = new Dictionary<int, int>();
-        var callTreeRoot = new CallTreeNode(-1, "Total");
-        var callTreeTotal = 0d;
-
-        var hasSampledProfile = false;
-        var hasSampleUnit = false;
-        var hasTimeUnit = false;
-
-        var parsedProfiles = 0;
-        foreach (var profile in profilesElement.EnumerateArray())
-        {
-            var (timeScale, isSampleUnit) = GetUnitScale(profile);
+            var (timeScale, isSampleUnit) = SpeedscopeProfileUnitResolver.GetUnitScale(profile);
 
             if (profile.TryGetProperty("events", out var eventsElement) &&
                 eventsElement.ValueKind == JsonValueKind.Array)
             {
-                parsedProfiles++;
-                hasTimeUnit = true;
-                ProcessEventedProfile(
-                    eventsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameSelfTimes,
-                    frameCounts,
-                    ref callTreeTotal,
-                    timeScale);
+                state.RegisterEventedProfile();
+                SpeedscopeEventedProfileProcessor.Process(eventsElement, state, timeScale);
                 continue;
             }
 
             if (profile.TryGetProperty("samples", out var samplesElement) &&
                 samplesElement.ValueKind == JsonValueKind.Array)
             {
-                JsonElement? weightsElement = null;
-                if (profile.TryGetProperty("weights", out var weightsValue) &&
-                    weightsValue.ValueKind == JsonValueKind.Array)
-                {
-                    weightsElement = weightsValue;
-                }
-
-                parsedProfiles++;
-                hasSampledProfile = true;
-                if (isSampleUnit)
-                {
-                    hasSampleUnit = true;
-                }
-                else
-                {
-                    hasTimeUnit = true;
-                }
-                ProcessSampledProfile(
+                state.RegisterSampledProfile(isSampleUnit);
+                SpeedscopeSampledProfileProcessor.Process(
                     samplesElement,
-                    weightsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameCounts,
-                    ref callTreeTotal,
+                    SpeedscopeDocumentReader.ReadWeights(profile),
+                    state,
                     timeScale,
                     isSampleUnit);
             }
         }
 
-        if (parsedProfiles == 0)
-        {
-            return null;
-        }
-
-        var allFunctions = new List<FunctionSample>();
-        var totalTime = frameTimes.Values.Sum();
-
-        if (callTreeTotal <= 0)
-        {
-            callTreeTotal = SumCallTreeTotals(callTreeRoot);
-        }
-
-        callTreeRoot.Total = callTreeTotal;
-        callTreeRoot.Calls = SumCallTreeCalls(callTreeRoot);
-
-        foreach (var child in callTreeRoot.Children.Values)
-        {
-            if (child.HasTiming)
-            {
-                callTreeRoot.UpdateTiming(child.MinStart, child.MaxEnd);
-            }
-        }
-
-        foreach (var (frameIdx, timeSpent) in frameTimes.OrderByDescending(kv => kv.Value))
-        {
-            var name = frameIdx < framesList.Count ? framesList[frameIdx] : "Unknown";
-            frameCounts.TryGetValue(frameIdx, out var calls);
-            allFunctions.Add(new FunctionSample(name, timeSpent, calls, frameIdx));
-        }
-
-        var timeUnitLabel = hasSampleUnit && !hasTimeUnit ? "samples" : "ms";
-        var countLabel = hasSampledProfile ? "Samples" : "Calls";
-        var countSuffix = hasSampledProfile ? " samp" : "x";
-
-        return new CpuProfileResult(
-            allFunctions,
-            totalTime,
-            callTreeRoot,
-            callTreeTotal,
-            speedscopePath,
-            timeUnitLabel,
-            countLabel,
-            countSuffix);
-    }
-
-    private static void ProcessEventedProfile(
-        JsonElement eventsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, double> frameSelfTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale)
-    {
-        var stack = new List<(CallTreeNode Node, double Start, int FrameIdx)>();
-        var hasLast = false;
-        var lastAt = 0d;
-
-        foreach (var evt in eventsElement.EnumerateArray())
-        {
-            if (!evt.TryGetProperty("type", out var typeElement) ||
-                typeElement.ValueKind != JsonValueKind.String)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("frame", out var frameElement) ||
-                frameElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("at", out var atElement) ||
-                atElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            var eventType = typeElement.GetString();
-            var frameIdx = frameElement.GetInt32();
-            var at = atElement.GetDouble() * timeScale;
-
-            if (hasLast && stack.Count > 0)
-            {
-                var topIdx = stack[^1].FrameIdx;
-                frameSelfTimes.TryGetValue(topIdx, out var selfTime);
-                var delta = at - lastAt;
-                frameSelfTimes[topIdx] = selfTime + delta;
-                stack[^1].Node.Self += delta;
-            }
-
-            hasLast = true;
-            lastAt = at;
-
-            if (string.Equals(eventType, "O", StringComparison.Ordinal))
-            {
-                var parentNode = stack.Count > 0 ? stack[^1].Node : callTreeRoot;
-                var childNode = GetOrCreateCallTreeChild(parentNode, frameIdx, framesList);
-                childNode.Calls += 1;
-                stack.Add((childNode, at, frameIdx));
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + 1;
-            }
-            else if (string.Equals(eventType, "C", StringComparison.Ordinal))
-            {
-                if (stack.Count > 0 && stack[^1].FrameIdx == frameIdx)
-                {
-                    var (node, openTime, _) = stack[^1];
-                    stack.RemoveAt(stack.Count - 1);
-                    var duration = at - openTime;
-                    frameTimes.TryGetValue(frameIdx, out var time);
-                    frameTimes[frameIdx] = time + duration;
-                    node.Total += duration;
-                    node.UpdateTiming(openTime, at);
-                    if (stack.Count == 0)
-                    {
-                        callTreeTotal += duration;
-                    }
-                }
-            }
-        }
-    }
-
-    private static void ProcessSampledProfile(
-        JsonElement samplesElement,
-        JsonElement? weightsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale,
-        bool isSampleUnit)
-    {
-        var hasWeights = weightsElement.HasValue &&
-                         weightsElement.Value.ValueKind == JsonValueKind.Array;
-        var weightsArray = weightsElement.GetValueOrDefault();
-        var sampleIndex = 0;
-
-        foreach (var sample in samplesElement.EnumerateArray())
-        {
-            if (sample.ValueKind != JsonValueKind.Array)
-            {
-                sampleIndex++;
-                continue;
-            }
-
-            var weight = 1d;
-            if (hasWeights && sampleIndex < weightsArray.GetArrayLength())
-            {
-                var weightElement = weightsArray[sampleIndex];
-                if (weightElement.ValueKind == JsonValueKind.Number)
-                {
-                    weight = weightElement.GetDouble();
-                }
-            }
-
-            var timeWeight = weight * timeScale;
-            var callWeight = 1;
-            if (isSampleUnit)
-            {
-                callWeight = weight <= 0
-                    ? 0
-                    : Math.Max(1, (int)Math.Round(weight));
-            }
-
-            var current = callTreeRoot;
-            var hasFrame = false;
-            foreach (var frameIdxElement in sample.EnumerateArray())
-            {
-                if (frameIdxElement.ValueKind != JsonValueKind.Number)
-                {
-                    continue;
-                }
-
-                var frameIdx = frameIdxElement.GetInt32();
-                if (frameIdx < 0)
-                {
-                    continue;
-                }
-
-                hasFrame = true;
-                var child = GetOrCreateCallTreeChild(current, frameIdx, framesList);
-                child.Total += timeWeight;
-                child.Calls += callWeight;
-                frameTimes.TryGetValue(frameIdx, out var time);
-                frameTimes[frameIdx] = time + timeWeight;
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + callWeight;
-                current = child;
-            }
-
-            if (hasFrame)
-            {
-                current.Self += timeWeight;
-                callTreeTotal += timeWeight;
-            }
-
-            sampleIndex++;
-        }
-    }
-
-    private static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
-    {
-        if (!profile.TryGetProperty("unit", out var unitElement) ||
-            unitElement.ValueKind != JsonValueKind.String)
-        {
-            return (1d, false);
-        }
-
-        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
-        return unit switch
-        {
-            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
-            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
-            "milliseconds" or "millisecond" or "ms" => (1d, false),
-            "seconds" or "second" or "s" => (1_000d, false),
-            "samples" or "sample" => (1d, true),
-            _ => (1d, false)
-        };
-    }
-
-    private static CallTreeNode GetOrCreateCallTreeChild(
-        CallTreeNode parent,
-        int frameIdx,
-        IReadOnlyList<string> frames)
-    {
-        if (!parent.Children.TryGetValue(frameIdx, out var child))
-        {
-            var name = frameIdx >= 0 && frameIdx < frames.Count ? frames[frameIdx] : "Unknown";
-            child = new CallTreeNode(frameIdx, name);
-            parent.Children[frameIdx] = child;
-        }
-
-        return child;
-    }
-
-    private static double SumCallTreeTotals(CallTreeNode node)
-    {
-        var sum = 0d;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Total;
-        }
-        return sum;
-    }
-
-    private static int SumCallTreeCalls(CallTreeNode node)
-    {
-        var sum = 0;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Calls;
-        }
-        return sum;
+        return state.BuildResult(speedscopePath);
     }
 }

--- a/src/ProfileTool/Cpu/SpeedscopeProfileUnitResolver.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeProfileUnitResolver.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal static class SpeedscopeProfileUnitResolver
+{
+    public static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
+    {
+        if (!profile.TryGetProperty("unit", out var unitElement) ||
+            unitElement.ValueKind != JsonValueKind.String)
+        {
+            return (1d, false);
+        }
+
+        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
+        return unit switch
+        {
+            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
+            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
+            "milliseconds" or "millisecond" or "ms" => (1d, false),
+            "seconds" or "second" or "s" => (1_000d, false),
+            "samples" or "sample" => (1d, true),
+            _ => (1d, false)
+        };
+    }
+}

--- a/src/ProfileTool/Cpu/SpeedscopeSampledProfileProcessor.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeSampledProfileProcessor.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal static class SpeedscopeSampledProfileProcessor
+{
+    public static void Process(
+        JsonElement samplesElement,
+        JsonElement? weightsElement,
+        SpeedscopeAggregationState state,
+        double timeScale,
+        bool isSampleUnit)
+    {
+        var hasWeights = weightsElement.HasValue &&
+                         weightsElement.Value.ValueKind == JsonValueKind.Array;
+        var weightsArray = weightsElement.GetValueOrDefault();
+        var sampleIndex = 0;
+
+        foreach (var sample in samplesElement.EnumerateArray())
+        {
+            if (sample.ValueKind != JsonValueKind.Array)
+            {
+                sampleIndex++;
+                continue;
+            }
+
+            var weight = GetWeight(hasWeights, weightsArray, sampleIndex);
+            var timeWeight = weight * timeScale;
+            var callWeight = GetCallWeight(weight, isSampleUnit);
+
+            var current = state.Root;
+            var hasFrame = false;
+            foreach (var frameIdxElement in sample.EnumerateArray())
+            {
+                if (frameIdxElement.ValueKind != JsonValueKind.Number)
+                {
+                    continue;
+                }
+
+                var frameIdx = frameIdxElement.GetInt32();
+                if (frameIdx < 0)
+                {
+                    continue;
+                }
+
+                hasFrame = true;
+                current = AddFrameToPath(current, frameIdx, state, timeWeight, callWeight);
+            }
+
+            if (hasFrame)
+            {
+                current.Self += timeWeight;
+                state.AddRootDuration(timeWeight);
+            }
+
+            sampleIndex++;
+        }
+    }
+
+    private static double GetWeight(bool hasWeights, JsonElement weightsArray, int sampleIndex)
+    {
+        if (!hasWeights || sampleIndex >= weightsArray.GetArrayLength())
+        {
+            return 1d;
+        }
+
+        var weightElement = weightsArray[sampleIndex];
+        return weightElement.ValueKind == JsonValueKind.Number
+            ? weightElement.GetDouble()
+            : 1d;
+    }
+
+    private static int GetCallWeight(double weight, bool isSampleUnit)
+    {
+        if (!isSampleUnit)
+        {
+            return 1;
+        }
+
+        return weight <= 0
+            ? 0
+            : Math.Max(1, (int)Math.Round(weight));
+    }
+
+    private static CallTreeNode AddFrameToPath(
+        CallTreeNode parent,
+        int frameIdx,
+        SpeedscopeAggregationState state,
+        double timeWeight,
+        int callWeight)
+    {
+        var child = state.GetOrCreateChild(parent, frameIdx);
+        child.Total += timeWeight;
+        child.Calls += callWeight;
+        state.AddFrameTime(frameIdx, timeWeight);
+        state.AddFrameCalls(frameIdx, callWeight);
+        return child;
+    }
+}

--- a/src/ProfileTool/Rendering/CompilerGeneratedMethodDisplayFormatter.cs
+++ b/src/ProfileTool/Rendering/CompilerGeneratedMethodDisplayFormatter.cs
@@ -1,0 +1,143 @@
+using System;
+
+namespace Asynkron.Profiler;
+
+internal static class CompilerGeneratedMethodDisplayFormatter
+{
+    private static readonly char[] MethodTerminatorCharacters = new[] { '|', '>' };
+
+    public static string? TryFormat(string typePart, string methodPart)
+    {
+        if (string.IsNullOrWhiteSpace(typePart) || string.IsNullOrWhiteSpace(methodPart))
+        {
+            return null;
+        }
+
+        if (string.Equals(methodPart, "MoveNext", StringComparison.Ordinal))
+        {
+            var stateMethod = ExtractStateMachineMethodName(typePart);
+            if (!string.IsNullOrWhiteSpace(stateMethod))
+            {
+                return $"StateMachine.{stateMethod}.MoveNext";
+            }
+        }
+
+        var lambdaOwner = ExtractLambdaOwner(methodPart);
+        if (string.IsNullOrWhiteSpace(lambdaOwner))
+        {
+            return null;
+        }
+
+        var ownerType = IsDisplayClassType(typePart)
+            ? ExtractOuterType(typePart)
+            : typePart;
+        var prefix = string.IsNullOrWhiteSpace(ownerType)
+            ? string.Empty
+            : TypeDisplayNameFormatter.Format(ownerType) + ".";
+
+        return $"{prefix}{lambdaOwner} lambda";
+    }
+
+    private static bool IsDisplayClassType(string typePart)
+    {
+        return typePart.Contains("<>c__DisplayClass", StringComparison.Ordinal) ||
+               typePart.Contains("+<>c", StringComparison.Ordinal);
+    }
+
+    private static string? ExtractStateMachineMethodName(string typePart)
+    {
+        var localFunctionIndex = typePart.LastIndexOf("g__", StringComparison.Ordinal);
+        if (localFunctionIndex >= 0)
+        {
+            var localStart = localFunctionIndex + 3;
+            var localEnd = typePart.IndexOfAny(MethodTerminatorCharacters, localStart);
+            if (localEnd < 0)
+            {
+                localEnd = typePart.Length;
+            }
+
+            var name = typePart[localStart..localEnd];
+            return TrimCompilerGeneratedName(name);
+        }
+
+        var methodEnd = typePart.LastIndexOf(">d__", StringComparison.Ordinal);
+        if (methodEnd < 0)
+        {
+            methodEnd = typePart.LastIndexOf(">d", StringComparison.Ordinal);
+        }
+
+        if (methodEnd < 0)
+        {
+            methodEnd = typePart.LastIndexOf('>');
+        }
+
+        if (methodEnd < 0)
+        {
+            return null;
+        }
+
+        var methodStart = typePart.LastIndexOf('<', methodEnd);
+        if (methodStart < 0 || methodStart + 1 >= methodEnd)
+        {
+            return null;
+        }
+
+        var methodName = typePart[(methodStart + 1)..methodEnd];
+        return TrimCompilerGeneratedName(methodName);
+    }
+
+    private static string? ExtractLambdaOwner(string methodPart)
+    {
+        var ownerStart = methodPart.IndexOf('<');
+        var ownerEnd = methodPart.IndexOf('>');
+        if (ownerStart < 0 || ownerEnd <= ownerStart)
+        {
+            return null;
+        }
+
+        var owner = TrimCompilerGeneratedName(methodPart[(ownerStart + 1)..ownerEnd]);
+        return string.IsNullOrWhiteSpace(owner) ? null : owner;
+    }
+
+    private static string ExtractOuterType(string typePart)
+    {
+        var markerIndex = typePart.IndexOf("+<", StringComparison.Ordinal);
+        if (markerIndex > 0)
+        {
+            return typePart[..markerIndex];
+        }
+
+        markerIndex = typePart.IndexOf("+<>c", StringComparison.Ordinal);
+        if (markerIndex > 0)
+        {
+            return typePart[..markerIndex];
+        }
+
+        return typePart;
+    }
+
+    private static string? TrimCompilerGeneratedName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        var trimmed = name.Trim();
+        while (trimmed.StartsWith('<') || trimmed.EndsWith('>'))
+        {
+            trimmed = trimmed.Trim('<', '>');
+        }
+
+        while (trimmed.EndsWith('$'))
+        {
+            trimmed = trimmed[..^1];
+            while (trimmed.EndsWith('>'))
+            {
+                trimmed = trimmed.TrimEnd('>');
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}

--- a/src/ProfileTool/Rendering/NameFormatter.cs
+++ b/src/ProfileTool/Rendering/NameFormatter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.RegularExpressions;
 
 namespace Asynkron.Profiler;
 
@@ -33,17 +32,17 @@ public static class NameFormatter
         {
             var typePart = name[..lastDot].TrimEnd('.');
             var methodPart = name[(lastDot + 1)..];
-            var compilerGenerated = FormatCompilerGeneratedMethod(typePart, methodPart);
+            var compilerGenerated = CompilerGeneratedMethodDisplayFormatter.TryFormat(typePart, methodPart);
             if (!string.IsNullOrWhiteSpace(compilerGenerated))
             {
                 return compilerGenerated;
             }
 
-            var formatted = $"{CleanTypeName(typePart)}.{methodPart}";
+            var formatted = $"{TypeDisplayNameFormatter.Format(typePart)}.{methodPart}";
             return EnsureReadableName(formatted);
         }
 
-        return EnsureReadableName(CleanTypeName(name));
+        return EnsureReadableName(TypeDisplayNameFormatter.Format(name));
     }
 
     public static string FormatTypeDisplayName(string rawName)
@@ -53,48 +52,7 @@ public static class NameFormatter
             return rawName;
         }
 
-        return CleanTypeName(rawName);
-    }
-
-    private static string CleanTypeName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return name;
-        }
-
-        var timeout = TimeSpan.FromMilliseconds(100);
-        var normalized = Regex.Replace(
-            name,
-            @"\b(?:[A-Za-z_][A-Za-z0-9_]*\.)+(?<type>[A-Za-z_][A-Za-z0-9_]*)",
-            "${type}",
-            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
-            timeout);
-
-        normalized = Regex.Replace(
-            normalized,
-            @"`\d+",
-            "",
-            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
-            timeout);
-
-        const string arrayToken = "__ARRAY__";
-        normalized = Regex.Replace(
-            normalized,
-            @"\[(?<commas>,*)\]",
-            match => $"{arrayToken}{match.Groups["commas"].Value}{arrayToken}",
-            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
-            timeout);
-        normalized = normalized.Replace('[', '<').Replace(']', '>');
-        normalized = Regex.Replace(
-            normalized,
-            $"{arrayToken}(?<commas>,*){arrayToken}",
-            match => $"[{match.Groups["commas"].Value}]",
-            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
-            timeout);
-        normalized = normalized.Replace('+', '.');
-
-        return normalized;
+        return TypeDisplayNameFormatter.Format(rawName);
     }
 
     private static bool IsUnmanagedCode(string name)
@@ -173,151 +131,5 @@ public static class NameFormatter
         }
 
         return -1;
-    }
-    private static string? FormatCompilerGeneratedMethod(string typePart, string methodPart)
-    {
-        if (string.IsNullOrWhiteSpace(typePart) || string.IsNullOrWhiteSpace(methodPart))
-        {
-            return null;
-        }
-
-        if (string.Equals(methodPart, "MoveNext", StringComparison.Ordinal))
-        {
-            var stateMethod = ExtractStateMachineMethodName(typePart);
-            if (!string.IsNullOrWhiteSpace(stateMethod))
-            {
-                return $"StateMachine.{stateMethod}.MoveNext";
-            }
-        }
-
-        var lambdaOwner = ExtractLambdaOwner(methodPart);
-        if (!string.IsNullOrWhiteSpace(lambdaOwner) && IsDisplayClassType(typePart))
-        {
-            var outerType = ExtractOuterType(typePart);
-            var prefix = string.IsNullOrWhiteSpace(outerType)
-                ? string.Empty
-                : CleanTypeName(outerType) + ".";
-            return $"{prefix}{lambdaOwner} lambda";
-        }
-
-        if (!string.IsNullOrWhiteSpace(lambdaOwner))
-        {
-            var prefix = string.IsNullOrWhiteSpace(typePart)
-                ? string.Empty
-                : CleanTypeName(typePart) + ".";
-            return $"{prefix}{lambdaOwner} lambda";
-        }
-
-        return null;
-    }
-
-    private static bool IsDisplayClassType(string typePart)
-    {
-        return typePart.Contains("<>c__DisplayClass", StringComparison.Ordinal) ||
-               typePart.Contains("+<>c", StringComparison.Ordinal);
-    }
-    private static readonly char[] anyOf = new[] { '|', '>' };
-
-    private static string? ExtractStateMachineMethodName(string typePart)
-    {
-        var localFunctionIndex = typePart.LastIndexOf("g__", StringComparison.Ordinal);
-        if (localFunctionIndex >= 0)
-        {
-            var localStart = localFunctionIndex + 3;
-            var localEnd = typePart.IndexOfAny(anyOf, localStart);
-            if (localEnd < 0)
-            {
-                localEnd = typePart.Length;
-            }
-
-            var name = typePart[localStart..localEnd];
-            return TrimCompilerGeneratedName(name);
-        }
-
-        var methodEnd = typePart.LastIndexOf(">d__", StringComparison.Ordinal);
-        if (methodEnd < 0)
-        {
-            methodEnd = typePart.LastIndexOf(">d", StringComparison.Ordinal);
-        }
-
-        if (methodEnd < 0)
-        {
-            methodEnd = typePart.LastIndexOf('>');
-        }
-
-        if (methodEnd < 0)
-        {
-            return null;
-        }
-
-        var methodStart = typePart.LastIndexOf('<', methodEnd);
-        if (methodStart < 0 || methodStart + 1 >= methodEnd)
-        {
-            return null;
-        }
-
-        var methodName = typePart[(methodStart + 1)..methodEnd];
-        return TrimCompilerGeneratedName(methodName);
-    }
-
-    private static string? ExtractLambdaOwner(string methodPart)
-    {
-        if (string.IsNullOrWhiteSpace(methodPart))
-        {
-            return null;
-        }
-
-        var ownerStart = methodPart.IndexOf('<');
-        var ownerEnd = methodPart.IndexOf('>');
-        if (ownerStart < 0 || ownerEnd <= ownerStart)
-        {
-            return null;
-        }
-
-        var owner = TrimCompilerGeneratedName(methodPart[(ownerStart + 1)..ownerEnd]);
-        return string.IsNullOrWhiteSpace(owner) ? null : owner;
-    }
-
-    private static string ExtractOuterType(string typePart)
-    {
-        var markerIndex = typePart.IndexOf("+<", StringComparison.Ordinal);
-        if (markerIndex > 0)
-        {
-            return typePart[..markerIndex];
-        }
-
-        markerIndex = typePart.IndexOf("+<>c", StringComparison.Ordinal);
-        if (markerIndex > 0)
-        {
-            return typePart[..markerIndex];
-        }
-
-        return typePart;
-    }
-
-    private static string? TrimCompilerGeneratedName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return null;
-        }
-
-        var trimmed = name.Trim();
-        while (trimmed.StartsWith('<') ||
-               trimmed.EndsWith('>'))
-        {
-            trimmed = trimmed.Trim('<', '>');
-        }
-
-        while (trimmed.EndsWith('$'))
-        {
-            trimmed = trimmed[..^1];
-            while (trimmed.EndsWith('>'))
-            {
-                trimmed = trimmed.TrimEnd('>');
-            }
-        }
-
-        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
 }

--- a/src/ProfileTool/Rendering/TypeDisplayNameFormatter.cs
+++ b/src/ProfileTool/Rendering/TypeDisplayNameFormatter.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Asynkron.Profiler;
+
+internal static class TypeDisplayNameFormatter
+{
+    private const string ArrayToken = "__ARRAY__";
+
+    public static string Format(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return name;
+        }
+
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var normalized = Regex.Replace(
+            name,
+            @"\b(?:[A-Za-z_][A-Za-z0-9_]*\.)+(?<type>[A-Za-z_][A-Za-z0-9_]*)",
+            "${type}",
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
+
+        normalized = Regex.Replace(
+            normalized,
+            @"`\d+",
+            string.Empty,
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
+
+        normalized = Regex.Replace(
+            normalized,
+            @"\[(?<commas>,*)\]",
+            match => $"{ArrayToken}{match.Groups["commas"].Value}{ArrayToken}",
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
+        normalized = normalized.Replace('[', '<').Replace(']', '>');
+        normalized = Regex.Replace(
+            normalized,
+            $"{ArrayToken}(?<commas>,*){ArrayToken}",
+            match => $"[{match.Groups["commas"].Value}]",
+            RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,
+            timeout);
+
+        return normalized.Replace('+', '.');
+    }
+}

--- a/src/ProfilerCore/Asynkron.Profiler.Core.csproj
+++ b/src/ProfilerCore/Asynkron.Profiler.Core.csproj
@@ -32,6 +32,8 @@
     <Compile Include="..\ProfileTool\Contention\*.cs" Link="Contention\%(Filename)%(Extension)" />
     <Compile Include="..\ProfileTool\Heap\*.cs" Link="Heap\%(Filename)%(Extension)" />
     <Compile Include="..\ProfileTool\Rendering\NameFormatter.cs" Link="Rendering\NameFormatter.cs" />
+    <Compile Include="..\ProfileTool\Rendering\CompilerGeneratedMethodDisplayFormatter.cs" Link="Rendering\CompilerGeneratedMethodDisplayFormatter.cs" />
+    <Compile Include="..\ProfileTool\Rendering\TypeDisplayNameFormatter.cs" Link="Rendering\TypeDisplayNameFormatter.cs" />
     <Compile Include="..\ProfileTool\Rendering\CompactTreeGuide.cs" Link="Rendering\CompactTreeGuide.cs" />
     <Compile Include="..\ProfileTool\ConsoleThemeHelpers.cs" Link="ConsoleThemeHelpers.cs" />
     <Compile Include="..\ProfileTool\Theme.cs" Link="Theme.cs" />

--- a/tests/Asynkron.Profiler.Tests/NameFormatterTests.cs
+++ b/tests/Asynkron.Profiler.Tests/NameFormatterTests.cs
@@ -8,6 +8,8 @@ public sealed class NameFormatterTests
     [InlineData("Program+<<<Main>$>g__EvaluateAsync|0_2>d.MoveNext", "StateMachine.EvaluateAsync.MoveNext")]
     [InlineData("Program+<<Main>$>d__0.MoveNext", "StateMachine.Main.MoveNext")]
     [InlineData("PromiseConstructor.<AttachStatics>b__5_0", "PromiseConstructor.AttachStatics lambda")]
+    [InlineData("Program+<>c__DisplayClass0_0.<Main>b__0", "Program.Main lambda")]
+    [InlineData("Program+<>c.<Run>b__1_0", "Program.Run lambda")]
     [InlineData("Asynkron.JsEngine.Ast.TypedAstEvaluator+TypedFunction.InvokeWithContext2(System.Int32)",
         "TypedAstEvaluator.TypedFunction.InvokeWithContext2")]
     [InlineData("UNMANAGED_CODE_TIME", "Unmanaged Code")]
@@ -27,6 +29,7 @@ public sealed class NameFormatterTests
     [InlineData("System.Int32[,]", "Int32[,]")]
     [InlineData("System.Collections.Generic.Dictionary`2[System.String,System.Int32[,]]",
         "Dictionary<String,Int32[,]>")]
+    [InlineData("Namespace.Outer+Inner", "Outer.Inner")]
     public void FormatsTypeNames(string raw, string expected)
     {
         var actual = NameFormatter.FormatTypeDisplayName(raw);

--- a/tests/Asynkron.Profiler.Tests/SpeedscopeParserTests.cs
+++ b/tests/Asynkron.Profiler.Tests/SpeedscopeParserTests.cs
@@ -6,6 +6,44 @@ namespace Asynkron.Profiler.Tests;
 public sealed class SpeedscopeParserTests
 {
     [Fact]
+    public void ReturnsNullForInvalidDocumentShape()
+    {
+        var result = SpeedscopeParser.ParseJson(
+            """
+            {
+              "shared": {},
+              "profiles": []
+            }
+            """);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReturnsNullWhenProfilesContainNoParsableSamples()
+    {
+        var result = SpeedscopeParser.ParseJson(
+            """
+            {
+              "shared": {
+                "frames": [
+                  { "name": "A" }
+                ]
+              },
+              "profiles": [
+                {
+                  "type": "evented",
+                  "name": "Thread 1",
+                  "events": "invalid"
+                }
+              ]
+            }
+            """);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void AggregatesAllProfilesInSpeedscope()
     {
         var result = Parse(CreateSpeedscopeJson(
@@ -92,6 +130,115 @@ public sealed class SpeedscopeParserTests
         AssertFunction(sampleA, 3d, 3);
         AssertFunction(sampleB, 2d, 2);
         AssertFunction(sampleC, 1d, 1);
+    }
+
+    [Fact]
+    public void CapturesSelfTimeAndTimingBoundsForEventedProfiles()
+    {
+        var result = Parse(CreateSpeedscopeJson(
+            """
+                {
+                  "type": "evented",
+                  "name": "Thread 1",
+                  "events": [
+                    { "type": "O", "frame": 0, "at": 0 },
+                    { "type": "O", "frame": 1, "at": 1 },
+                    { "type": "C", "frame": 1, "at": 3 },
+                    { "type": "C", "frame": 0, "at": 5 }
+                  ]
+                }
+            """));
+
+        var root = result.CallTreeRoot;
+        var nodeA = root.Children.Values.Single(node => node.Name == "A");
+        var nodeB = nodeA.Children.Values.Single(node => node.Name == "B");
+
+        Assert.Equal(3d, nodeA.Self, 3);
+        Assert.Equal(2d, nodeB.Self, 3);
+        Assert.True(root.HasTiming);
+        Assert.Equal(0d, root.MinStart, 3);
+        Assert.Equal(5d, root.MaxEnd, 3);
+    }
+
+    [Fact]
+    public void ConvertsSecondUnitsToMilliseconds()
+    {
+        var result = Parse(CreateSpeedscopeJson(
+            """
+                {
+                  "type": "sampled",
+                  "unit": "seconds",
+                  "samples": [
+                    [0],
+                    [0]
+                  ],
+                  "weights": [0.001, 0.002]
+                }
+            """));
+
+        var sampleA = result.AllFunctions.Single(sample => sample.Name == "A");
+        Assert.Equal("ms", result.TimeUnitLabel);
+        Assert.Equal("Samples", result.CountLabel);
+        Assert.Equal(" samp", result.CountSuffix);
+        Assert.Equal(3d, sampleA.TimeMs, 3);
+        Assert.Equal(2, sampleA.Calls);
+    }
+
+    [Fact]
+    public void UsesUnknownForBlankMissingAndOutOfRangeFrames()
+    {
+        var result = Parse(
+            """
+            {
+              "shared": {
+                "frames": [
+                  { "name": "" },
+                  {}
+                ]
+              },
+              "profiles": [
+                {
+                  "type": "sampled",
+                  "samples": [
+                    [0, 1, 2]
+                  ]
+                }
+              ]
+            }
+            """);
+
+        Assert.Equal(3, result.AllFunctions.Count);
+        Assert.All(result.AllFunctions, sample => Assert.Equal("Unknown", sample.Name));
+        var unknownLeaf = result.CallTreeRoot.Children.Values.Single().Children.Values.Single().Children.Values.Single();
+        Assert.Equal("Unknown", unknownLeaf.Name);
+    }
+
+    [Fact]
+    public void UsesSampleLabelsWhenMixingEventedAndSampledProfiles()
+    {
+        var result = Parse(CreateSpeedscopeJson(
+            """
+                {
+                  "type": "evented",
+                  "name": "Thread 1",
+                  "events": [
+                    { "type": "O", "frame": 0, "at": 0 },
+                    { "type": "C", "frame": 0, "at": 1 }
+                  ]
+                },
+                {
+                  "type": "sampled",
+                  "unit": "samples",
+                  "samples": [
+                    [0, 1]
+                  ],
+                  "weights": [2]
+                }
+            """));
+
+        Assert.Equal("ms", result.TimeUnitLabel);
+        Assert.Equal("Samples", result.CountLabel);
+        Assert.Equal(" samp", result.CountSuffix);
     }
 
     private static CpuProfileResult Parse(string json)


### PR DESCRIPTION
﻿## Summary
- Split `NameFormatter` into focused helpers for compiler-generated method names and type-display normalization.
- Split `SpeedscopeParser` into a thin facade plus document reading, unit resolution, aggregation state, and separate evented/sampled processors.
- Added characterization tests for formatter behavior and for speedscope invalid-shape, timing, unit-conversion, unknown-frame, and mixed-profile label handling.
- Updated `Asynkron.Profiler.Core.csproj` so the shared formatter helpers are compiled into the core assembly.

## Testing
- `dotnet format Asynkron.Profiler.sln --verify-no-changes`
- `dotnet build Asynkron.Profiler.sln -warnaserror --disable-build-servers`
- `dotnet test Asynkron.Profiler.sln --disable-build-servers`
- `quickdup -path src -ext .cs -select 0..20 -min 2 -exclude ".g.,.generated."`

## Notes
- `roslynator fix Asynkron.Profiler.sln` was attempted as part of the pre-PR flow, but the current `roslynator.dotnet.cli` release is incompatible with this repo's .NET 10 preview SDK and fails while loading the solution. The repo was therefore validated with `dotnet format` plus warning-as-error build/test instead.