### PR TITLE
Refactor Speedscope parsing and complete pre-PR verification

### DIFF
--- a/src/ProfileTool/Cpu/SpeedscopeParser.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeParser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace Asynkron.Profiler;
@@ -23,349 +22,53 @@ public static class SpeedscopeParser
     private static CpuProfileResult? ParseDocument(JsonDocument doc, string? speedscopePath)
     {
         var root = doc.RootElement;
+        if (!TryReadFrames(root, out var frames) ||
+            !TryGetProfiles(root, out var profilesElement))
+        {
+            return null;
+        }
+
+        var accumulator = new SpeedscopeProfileAccumulator(frames, speedscopePath);
+        foreach (var profile in profilesElement.EnumerateArray())
+        {
+            accumulator.TryProcess(profile);
+        }
+
+        return accumulator.BuildResult();
+    }
+
+    private static bool TryReadFrames(JsonElement root, out IReadOnlyList<string> frames)
+    {
+        frames = Array.Empty<string>();
         if (!root.TryGetProperty("shared", out var shared) ||
             !shared.TryGetProperty("frames", out var framesElement) ||
             framesElement.ValueKind != JsonValueKind.Array)
         {
-            return null;
+            return false;
         }
 
-        if (!root.TryGetProperty("profiles", out var profilesElement) ||
-            profilesElement.ValueKind != JsonValueKind.Array)
-        {
-            return null;
-        }
-
-        var framesList = new List<string>();
+        var frameNames = new List<string>();
         foreach (var frame in framesElement.EnumerateArray())
         {
             var name = frame.TryGetProperty("name", out var nameElement)
                 ? nameElement.GetString()
                 : null;
-            framesList.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
+            frameNames.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
         }
 
-        var frameTimes = new Dictionary<int, double>();
-        var frameSelfTimes = new Dictionary<int, double>();
-        var frameCounts = new Dictionary<int, int>();
-        var callTreeRoot = new CallTreeNode(-1, "Total");
-        var callTreeTotal = 0d;
-
-        var hasSampledProfile = false;
-        var hasSampleUnit = false;
-        var hasTimeUnit = false;
-
-        var parsedProfiles = 0;
-        foreach (var profile in profilesElement.EnumerateArray())
-        {
-            var (timeScale, isSampleUnit) = GetUnitScale(profile);
-
-            if (profile.TryGetProperty("events", out var eventsElement) &&
-                eventsElement.ValueKind == JsonValueKind.Array)
-            {
-                parsedProfiles++;
-                hasTimeUnit = true;
-                ProcessEventedProfile(
-                    eventsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameSelfTimes,
-                    frameCounts,
-                    ref callTreeTotal,
-                    timeScale);
-                continue;
-            }
-
-            if (profile.TryGetProperty("samples", out var samplesElement) &&
-                samplesElement.ValueKind == JsonValueKind.Array)
-            {
-                JsonElement? weightsElement = null;
-                if (profile.TryGetProperty("weights", out var weightsValue) &&
-                    weightsValue.ValueKind == JsonValueKind.Array)
-                {
-                    weightsElement = weightsValue;
-                }
-
-                parsedProfiles++;
-                hasSampledProfile = true;
-                if (isSampleUnit)
-                {
-                    hasSampleUnit = true;
-                }
-                else
-                {
-                    hasTimeUnit = true;
-                }
-                ProcessSampledProfile(
-                    samplesElement,
-                    weightsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameCounts,
-                    ref callTreeTotal,
-                    timeScale,
-                    isSampleUnit);
-            }
-        }
-
-        if (parsedProfiles == 0)
-        {
-            return null;
-        }
-
-        var allFunctions = new List<FunctionSample>();
-        var totalTime = frameTimes.Values.Sum();
-
-        if (callTreeTotal <= 0)
-        {
-            callTreeTotal = SumCallTreeTotals(callTreeRoot);
-        }
-
-        callTreeRoot.Total = callTreeTotal;
-        callTreeRoot.Calls = SumCallTreeCalls(callTreeRoot);
-
-        foreach (var child in callTreeRoot.Children.Values)
-        {
-            if (child.HasTiming)
-            {
-                callTreeRoot.UpdateTiming(child.MinStart, child.MaxEnd);
-            }
-        }
-
-        foreach (var (frameIdx, timeSpent) in frameTimes.OrderByDescending(kv => kv.Value))
-        {
-            var name = frameIdx < framesList.Count ? framesList[frameIdx] : "Unknown";
-            frameCounts.TryGetValue(frameIdx, out var calls);
-            allFunctions.Add(new FunctionSample(name, timeSpent, calls, frameIdx));
-        }
-
-        var timeUnitLabel = hasSampleUnit && !hasTimeUnit ? "samples" : "ms";
-        var countLabel = hasSampledProfile ? "Samples" : "Calls";
-        var countSuffix = hasSampledProfile ? " samp" : "x";
-
-        return new CpuProfileResult(
-            allFunctions,
-            totalTime,
-            callTreeRoot,
-            callTreeTotal,
-            speedscopePath,
-            timeUnitLabel,
-            countLabel,
-            countSuffix);
+        frames = frameNames;
+        return true;
     }
 
-    private static void ProcessEventedProfile(
-        JsonElement eventsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, double> frameSelfTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale)
+    private static bool TryGetProfiles(JsonElement root, out JsonElement profilesElement)
     {
-        var stack = new List<(CallTreeNode Node, double Start, int FrameIdx)>();
-        var hasLast = false;
-        var lastAt = 0d;
-
-        foreach (var evt in eventsElement.EnumerateArray())
+        if (root.TryGetProperty("profiles", out profilesElement) &&
+            profilesElement.ValueKind == JsonValueKind.Array)
         {
-            if (!evt.TryGetProperty("type", out var typeElement) ||
-                typeElement.ValueKind != JsonValueKind.String)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("frame", out var frameElement) ||
-                frameElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("at", out var atElement) ||
-                atElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            var eventType = typeElement.GetString();
-            var frameIdx = frameElement.GetInt32();
-            var at = atElement.GetDouble() * timeScale;
-
-            if (hasLast && stack.Count > 0)
-            {
-                var topIdx = stack[^1].FrameIdx;
-                frameSelfTimes.TryGetValue(topIdx, out var selfTime);
-                var delta = at - lastAt;
-                frameSelfTimes[topIdx] = selfTime + delta;
-                stack[^1].Node.Self += delta;
-            }
-
-            hasLast = true;
-            lastAt = at;
-
-            if (string.Equals(eventType, "O", StringComparison.Ordinal))
-            {
-                var parentNode = stack.Count > 0 ? stack[^1].Node : callTreeRoot;
-                var childNode = GetOrCreateCallTreeChild(parentNode, frameIdx, framesList);
-                childNode.Calls += 1;
-                stack.Add((childNode, at, frameIdx));
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + 1;
-            }
-            else if (string.Equals(eventType, "C", StringComparison.Ordinal))
-            {
-                if (stack.Count > 0 && stack[^1].FrameIdx == frameIdx)
-                {
-                    var (node, openTime, _) = stack[^1];
-                    stack.RemoveAt(stack.Count - 1);
-                    var duration = at - openTime;
-                    frameTimes.TryGetValue(frameIdx, out var time);
-                    frameTimes[frameIdx] = time + duration;
-                    node.Total += duration;
-                    node.UpdateTiming(openTime, at);
-                    if (stack.Count == 0)
-                    {
-                        callTreeTotal += duration;
-                    }
-                }
-            }
-        }
-    }
-
-    private static void ProcessSampledProfile(
-        JsonElement samplesElement,
-        JsonElement? weightsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale,
-        bool isSampleUnit)
-    {
-        var hasWeights = weightsElement.HasValue &&
-                         weightsElement.Value.ValueKind == JsonValueKind.Array;
-        var weightsArray = weightsElement.GetValueOrDefault();
-        var sampleIndex = 0;
-
-        foreach (var sample in samplesElement.EnumerateArray())
-        {
-            if (sample.ValueKind != JsonValueKind.Array)
-            {
-                sampleIndex++;
-                continue;
-            }
-
-            var weight = 1d;
-            if (hasWeights && sampleIndex < weightsArray.GetArrayLength())
-            {
-                var weightElement = weightsArray[sampleIndex];
-                if (weightElement.ValueKind == JsonValueKind.Number)
-                {
-                    weight = weightElement.GetDouble();
-                }
-            }
-
-            var timeWeight = weight * timeScale;
-            var callWeight = 1;
-            if (isSampleUnit)
-            {
-                callWeight = weight <= 0
-                    ? 0
-                    : Math.Max(1, (int)Math.Round(weight));
-            }
-
-            var current = callTreeRoot;
-            var hasFrame = false;
-            foreach (var frameIdxElement in sample.EnumerateArray())
-            {
-                if (frameIdxElement.ValueKind != JsonValueKind.Number)
-                {
-                    continue;
-                }
-
-                var frameIdx = frameIdxElement.GetInt32();
-                if (frameIdx < 0)
-                {
-                    continue;
-                }
-
-                hasFrame = true;
-                var child = GetOrCreateCallTreeChild(current, frameIdx, framesList);
-                child.Total += timeWeight;
-                child.Calls += callWeight;
-                frameTimes.TryGetValue(frameIdx, out var time);
-                frameTimes[frameIdx] = time + timeWeight;
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + callWeight;
-                current = child;
-            }
-
-            if (hasFrame)
-            {
-                current.Self += timeWeight;
-                callTreeTotal += timeWeight;
-            }
-
-            sampleIndex++;
-        }
-    }
-
-    private static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
-    {
-        if (!profile.TryGetProperty("unit", out var unitElement) ||
-            unitElement.ValueKind != JsonValueKind.String)
-        {
-            return (1d, false);
+            return true;
         }
 
-        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
-        return unit switch
-        {
-            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
-            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
-            "milliseconds" or "millisecond" or "ms" => (1d, false),
-            "seconds" or "second" or "s" => (1_000d, false),
-            "samples" or "sample" => (1d, true),
-            _ => (1d, false)
-        };
-    }
-
-    private static CallTreeNode GetOrCreateCallTreeChild(
-        CallTreeNode parent,
-        int frameIdx,
-        IReadOnlyList<string> frames)
-    {
-        if (!parent.Children.TryGetValue(frameIdx, out var child))
-        {
-            var name = frameIdx >= 0 && frameIdx < frames.Count ? frames[frameIdx] : "Unknown";
-            child = new CallTreeNode(frameIdx, name);
-            parent.Children[frameIdx] = child;
-        }
-
-        return child;
-    }
-
-    private static double SumCallTreeTotals(CallTreeNode node)
-    {
-        var sum = 0d;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Total;
-        }
-        return sum;
-    }
-
-    private static int SumCallTreeCalls(CallTreeNode node)
-    {
-        var sum = 0;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Calls;
-        }
-        return sum;
+        profilesElement = default;
+        return false;
     }
 }

--- a/src/ProfileTool/Cpu/SpeedscopeProfileAccumulator.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeProfileAccumulator.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal sealed class SpeedscopeProfileAccumulator
+{
+    private readonly IReadOnlyList<string> _frames;
+    private readonly string? _speedscopePath;
+    private readonly Dictionary<int, double> _frameTimes = new();
+    private readonly Dictionary<int, int> _frameCounts = new();
+    private readonly CallTreeNode _callTreeRoot = CallTreeNode.CreateRoot();
+    private double _callTreeTotal;
+    private bool _hasSampledProfile;
+    private bool _hasSampleUnit;
+    private bool _hasTimeUnit;
+    private int _parsedProfiles;
+
+    public SpeedscopeProfileAccumulator(IReadOnlyList<string> frames, string? speedscopePath)
+    {
+        _frames = frames;
+        _speedscopePath = speedscopePath;
+    }
+
+    public void TryProcess(JsonElement profile)
+    {
+        var (timeScale, isSampleUnit) = GetUnitScale(profile);
+
+        if (TryGetEventedProfile(profile, out var eventsElement))
+        {
+            _parsedProfiles++;
+            _hasTimeUnit = true;
+            ProcessEventedProfile(eventsElement, timeScale);
+            return;
+        }
+
+        if (!TryGetSampledProfile(profile, out var samplesElement, out var weightsElement))
+        {
+            return;
+        }
+
+        _parsedProfiles++;
+        _hasSampledProfile = true;
+        if (isSampleUnit)
+        {
+            _hasSampleUnit = true;
+        }
+        else
+        {
+            _hasTimeUnit = true;
+        }
+
+        ProcessSampledProfile(samplesElement, weightsElement, timeScale, isSampleUnit);
+    }
+
+    public CpuProfileResult? BuildResult()
+    {
+        if (_parsedProfiles == 0)
+        {
+            return null;
+        }
+
+        if (_callTreeTotal <= 0)
+        {
+            _callTreeTotal = SumChildTotals(_callTreeRoot);
+        }
+
+        _callTreeRoot.Total = _callTreeTotal;
+        _callTreeRoot.Calls = SumChildCalls(_callTreeRoot);
+        UpdateRootTimingBounds();
+
+        var timeUnitLabel = _hasSampleUnit && !_hasTimeUnit ? "samples" : "ms";
+        var countLabel = _hasSampledProfile ? "Samples" : "Calls";
+        var countSuffix = _hasSampledProfile ? " samp" : "x";
+
+        return new CpuProfileResult(
+            BuildFunctions(),
+            _frameTimes.Values.Sum(),
+            _callTreeRoot,
+            _callTreeTotal,
+            _speedscopePath,
+            timeUnitLabel,
+            countLabel,
+            countSuffix);
+    }
+
+    private void ProcessEventedProfile(JsonElement eventsElement, double timeScale)
+    {
+        var stack = new List<(CallTreeNode Node, double Start, int FrameIdx)>();
+        var hasLast = false;
+        var lastAt = 0d;
+
+        foreach (var evt in eventsElement.EnumerateArray())
+        {
+            if (!TryReadEvent(evt, out var eventType, out var frameIdx, out var at, timeScale))
+            {
+                continue;
+            }
+
+            if (hasLast && stack.Count > 0)
+            {
+                stack[^1].Node.Self += at - lastAt;
+            }
+
+            hasLast = true;
+            lastAt = at;
+
+            if (string.Equals(eventType, "O", StringComparison.Ordinal))
+            {
+                var parentNode = stack.Count > 0 ? stack[^1].Node : _callTreeRoot;
+                var childNode = GetOrCreateChild(parentNode, frameIdx);
+                childNode.Calls += 1;
+                IncrementFrameCount(frameIdx, 1);
+                stack.Add((childNode, at, frameIdx));
+                continue;
+            }
+
+            if (!string.Equals(eventType, "C", StringComparison.Ordinal) ||
+                stack.Count == 0 ||
+                stack[^1].FrameIdx != frameIdx)
+            {
+                continue;
+            }
+
+            var (node, openTime, _) = stack[^1];
+            stack.RemoveAt(stack.Count - 1);
+            var duration = at - openTime;
+            AddFrameTime(frameIdx, duration);
+            node.Total += duration;
+            node.UpdateTiming(openTime, at);
+            if (stack.Count == 0)
+            {
+                _callTreeTotal += duration;
+            }
+        }
+    }
+
+    private void ProcessSampledProfile(
+        JsonElement samplesElement,
+        JsonElement? weightsElement,
+        double timeScale,
+        bool isSampleUnit)
+    {
+        var weightsArray = weightsElement.GetValueOrDefault();
+        var hasWeights = weightsElement.HasValue;
+        var sampleIndex = 0;
+
+        foreach (var sample in samplesElement.EnumerateArray())
+        {
+            if (sample.ValueKind != JsonValueKind.Array)
+            {
+                sampleIndex++;
+                continue;
+            }
+
+            var weight = ResolveWeight(weightsArray, hasWeights, sampleIndex);
+            var timeWeight = weight * timeScale;
+            var callWeight = ResolveCallWeight(weight, isSampleUnit);
+
+            var current = _callTreeRoot;
+            var hasFrame = false;
+            foreach (var frameIdxElement in sample.EnumerateArray())
+            {
+                if (frameIdxElement.ValueKind != JsonValueKind.Number)
+                {
+                    continue;
+                }
+
+                var frameIdx = frameIdxElement.GetInt32();
+                if (frameIdx < 0)
+                {
+                    continue;
+                }
+
+                hasFrame = true;
+                var child = GetOrCreateChild(current, frameIdx);
+                child.Total += timeWeight;
+                child.Calls += callWeight;
+                AddFrameTime(frameIdx, timeWeight);
+                IncrementFrameCount(frameIdx, callWeight);
+                current = child;
+            }
+
+            if (hasFrame)
+            {
+                current.Self += timeWeight;
+                _callTreeTotal += timeWeight;
+            }
+
+            sampleIndex++;
+        }
+    }
+
+    private List<FunctionSample> BuildFunctions()
+    {
+        var functions = new List<FunctionSample>();
+        foreach (var (frameIdx, timeSpent) in _frameTimes.OrderByDescending(entry => entry.Value))
+        {
+            _frameCounts.TryGetValue(frameIdx, out var calls);
+            functions.Add(new FunctionSample(GetFrameName(frameIdx), timeSpent, calls, frameIdx));
+        }
+
+        return functions;
+    }
+
+    private void UpdateRootTimingBounds()
+    {
+        foreach (var child in _callTreeRoot.Children.Values)
+        {
+            if (child.HasTiming)
+            {
+                _callTreeRoot.UpdateTiming(child.MinStart, child.MaxEnd);
+            }
+        }
+    }
+
+    private CallTreeNode GetOrCreateChild(CallTreeNode parent, int frameIdx)
+    {
+        if (!parent.Children.TryGetValue(frameIdx, out var child))
+        {
+            child = new CallTreeNode(frameIdx, GetFrameName(frameIdx));
+            parent.Children[frameIdx] = child;
+        }
+
+        return child;
+    }
+
+    private string GetFrameName(int frameIdx)
+    {
+        return frameIdx >= 0 && frameIdx < _frames.Count
+            ? _frames[frameIdx]
+            : "Unknown";
+    }
+
+    private void AddFrameTime(int frameIdx, double duration)
+    {
+        _frameTimes.TryGetValue(frameIdx, out var time);
+        _frameTimes[frameIdx] = time + duration;
+    }
+
+    private void IncrementFrameCount(int frameIdx, int count)
+    {
+        _frameCounts.TryGetValue(frameIdx, out var existing);
+        _frameCounts[frameIdx] = existing + count;
+    }
+
+    private static bool TryGetEventedProfile(JsonElement profile, out JsonElement eventsElement)
+    {
+        if (profile.TryGetProperty("events", out eventsElement) &&
+            eventsElement.ValueKind == JsonValueKind.Array)
+        {
+            return true;
+        }
+
+        eventsElement = default;
+        return false;
+    }
+
+    private static bool TryGetSampledProfile(
+        JsonElement profile,
+        out JsonElement samplesElement,
+        out JsonElement? weightsElement)
+    {
+        weightsElement = null;
+        if (!profile.TryGetProperty("samples", out samplesElement) ||
+            samplesElement.ValueKind != JsonValueKind.Array)
+        {
+            samplesElement = default;
+            return false;
+        }
+
+        if (profile.TryGetProperty("weights", out var weightsValue) &&
+            weightsValue.ValueKind == JsonValueKind.Array)
+        {
+            weightsElement = weightsValue;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadEvent(
+        JsonElement evt,
+        out string? eventType,
+        out int frameIdx,
+        out double at,
+        double timeScale)
+    {
+        eventType = null;
+        frameIdx = 0;
+        at = 0d;
+
+        if (!evt.TryGetProperty("type", out var typeElement) ||
+            typeElement.ValueKind != JsonValueKind.String ||
+            !evt.TryGetProperty("frame", out var frameElement) ||
+            frameElement.ValueKind != JsonValueKind.Number ||
+            !evt.TryGetProperty("at", out var atElement) ||
+            atElement.ValueKind != JsonValueKind.Number)
+        {
+            return false;
+        }
+
+        eventType = typeElement.GetString();
+        frameIdx = frameElement.GetInt32();
+        at = atElement.GetDouble() * timeScale;
+        return true;
+    }
+
+    private static double ResolveWeight(JsonElement weightsArray, bool hasWeights, int sampleIndex)
+    {
+        if (!hasWeights || sampleIndex >= weightsArray.GetArrayLength())
+        {
+            return 1d;
+        }
+
+        var weightElement = weightsArray[sampleIndex];
+        return weightElement.ValueKind == JsonValueKind.Number
+            ? weightElement.GetDouble()
+            : 1d;
+    }
+
+    private static int ResolveCallWeight(double weight, bool isSampleUnit)
+    {
+        if (!isSampleUnit)
+        {
+            return 1;
+        }
+
+        return weight <= 0
+            ? 0
+            : Math.Max(1, (int)Math.Round(weight));
+    }
+
+    private static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
+    {
+        if (!profile.TryGetProperty("unit", out var unitElement) ||
+            unitElement.ValueKind != JsonValueKind.String)
+        {
+            return (1d, false);
+        }
+
+        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
+        return unit switch
+        {
+            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
+            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
+            "milliseconds" or "millisecond" or "ms" => (1d, false),
+            "seconds" or "second" or "s" => (1_000d, false),
+            "samples" or "sample" => (1d, true),
+            _ => (1d, false)
+        };
+    }
+
+    private static double SumChildTotals(CallTreeNode node)
+    {
+        var sum = 0d;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Total;
+        }
+
+        return sum;
+    }
+
+    private static int SumChildCalls(CallTreeNode node)
+    {
+        var sum = 0;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Calls;
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION
﻿## Summary
- extracted Speedscope profile aggregation, call-tree construction, and result shaping into a dedicated `SpeedscopeProfileAccumulator`
- reduced `SpeedscopeParser` to document/file loading plus top-level JSON shape validation
- reran the pre-PR checks to confirm the repo still builds cleanly, has no reported duplication, and stays formatted

## Testing
- `DOTNET_ROLL_FORWARD=Major MSBuildSDKsPath=/usr/local/share/dotnet/sdk/9.0.304/Sdks roslynator fix src/ProfilerCore/Asynkron.Profiler.Core.csproj`
- `DOTNET_ROLL_FORWARD=Major MSBuildSDKsPath=/usr/local/share/dotnet/sdk/9.0.304/Sdks roslynator fix src/ProfileTool/ProfileTool.csproj`
- `DOTNET_ROLL_FORWARD=Major MSBuildSDKsPath=/usr/local/share/dotnet/sdk/9.0.304/Sdks roslynator fix tests/Asynkron.Profiler.Tests/Asynkron.Profiler.Tests.csproj`
- `dotnet build Asynkron.Profiler.sln -warnaserror`
- `dotnet test Asynkron.Profiler.sln --no-build`
- `quickdup -path . -ext .cs -select 0..20 -min 2 -exclude ".g.,.generated.,bin/,obj/"`
- `dotnet format Asynkron.Profiler.sln --verify-no-changes`

## Notes
- `roslynator fix Asynkron.Profiler.sln` is not usable in this environment because the installed Roslynator version fails when opening the solution directly against the current SDK, so the same check was run project-by-project instead.