### PR TITLE
Refactor Speedscope parsing into focused helpers

### DIFF
--- a/src/ProfileTool/Cpu/SpeedscopeJsonElementHelper.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeJsonElementHelper.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal static class SpeedscopeJsonElementHelper
+{
+    public static JsonElement? GetOptionalArray(JsonElement element, string propertyName)
+    {
+        return TryGetArray(element, propertyName, out var arrayElement)
+            ? arrayElement
+            : null;
+    }
+
+    public static bool TryGetArray(JsonElement element, string propertyName, out JsonElement arrayElement)
+    {
+        if (element.TryGetProperty(propertyName, out arrayElement) &&
+            arrayElement.ValueKind == JsonValueKind.Array)
+        {
+            return true;
+        }
+
+        arrayElement = default;
+        return false;
+    }
+}

--- a/src/ProfileTool/Cpu/SpeedscopeParser.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeParser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace Asynkron.Profiler;
@@ -23,349 +22,40 @@ public static class SpeedscopeParser
     private static CpuProfileResult? ParseDocument(JsonDocument doc, string? speedscopePath)
     {
         var root = doc.RootElement;
+        if (!TryReadFrames(root, out var frames) ||
+            !SpeedscopeJsonElementHelper.TryGetArray(root, "profiles", out var profilesElement))
+        {
+            return null;
+        }
+
+        var accumulator = new SpeedscopeProfileAccumulator(frames);
+        foreach (var profile in profilesElement.EnumerateArray())
+        {
+            accumulator.AddProfile(profile);
+        }
+
+        return accumulator.BuildResult(speedscopePath);
+    }
+
+    private static bool TryReadFrames(JsonElement root, out IReadOnlyList<string> frames)
+    {
+        frames = Array.Empty<string>();
         if (!root.TryGetProperty("shared", out var shared) ||
-            !shared.TryGetProperty("frames", out var framesElement) ||
-            framesElement.ValueKind != JsonValueKind.Array)
+            !SpeedscopeJsonElementHelper.TryGetArray(shared, "frames", out var framesElement))
         {
-            return null;
+            return false;
         }
 
-        if (!root.TryGetProperty("profiles", out var profilesElement) ||
-            profilesElement.ValueKind != JsonValueKind.Array)
-        {
-            return null;
-        }
-
-        var framesList = new List<string>();
+        var names = new List<string>();
         foreach (var frame in framesElement.EnumerateArray())
         {
             var name = frame.TryGetProperty("name", out var nameElement)
                 ? nameElement.GetString()
                 : null;
-            framesList.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
+            names.Add(string.IsNullOrWhiteSpace(name) ? "Unknown" : name);
         }
 
-        var frameTimes = new Dictionary<int, double>();
-        var frameSelfTimes = new Dictionary<int, double>();
-        var frameCounts = new Dictionary<int, int>();
-        var callTreeRoot = new CallTreeNode(-1, "Total");
-        var callTreeTotal = 0d;
-
-        var hasSampledProfile = false;
-        var hasSampleUnit = false;
-        var hasTimeUnit = false;
-
-        var parsedProfiles = 0;
-        foreach (var profile in profilesElement.EnumerateArray())
-        {
-            var (timeScale, isSampleUnit) = GetUnitScale(profile);
-
-            if (profile.TryGetProperty("events", out var eventsElement) &&
-                eventsElement.ValueKind == JsonValueKind.Array)
-            {
-                parsedProfiles++;
-                hasTimeUnit = true;
-                ProcessEventedProfile(
-                    eventsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameSelfTimes,
-                    frameCounts,
-                    ref callTreeTotal,
-                    timeScale);
-                continue;
-            }
-
-            if (profile.TryGetProperty("samples", out var samplesElement) &&
-                samplesElement.ValueKind == JsonValueKind.Array)
-            {
-                JsonElement? weightsElement = null;
-                if (profile.TryGetProperty("weights", out var weightsValue) &&
-                    weightsValue.ValueKind == JsonValueKind.Array)
-                {
-                    weightsElement = weightsValue;
-                }
-
-                parsedProfiles++;
-                hasSampledProfile = true;
-                if (isSampleUnit)
-                {
-                    hasSampleUnit = true;
-                }
-                else
-                {
-                    hasTimeUnit = true;
-                }
-                ProcessSampledProfile(
-                    samplesElement,
-                    weightsElement,
-                    framesList,
-                    callTreeRoot,
-                    frameTimes,
-                    frameCounts,
-                    ref callTreeTotal,
-                    timeScale,
-                    isSampleUnit);
-            }
-        }
-
-        if (parsedProfiles == 0)
-        {
-            return null;
-        }
-
-        var allFunctions = new List<FunctionSample>();
-        var totalTime = frameTimes.Values.Sum();
-
-        if (callTreeTotal <= 0)
-        {
-            callTreeTotal = SumCallTreeTotals(callTreeRoot);
-        }
-
-        callTreeRoot.Total = callTreeTotal;
-        callTreeRoot.Calls = SumCallTreeCalls(callTreeRoot);
-
-        foreach (var child in callTreeRoot.Children.Values)
-        {
-            if (child.HasTiming)
-            {
-                callTreeRoot.UpdateTiming(child.MinStart, child.MaxEnd);
-            }
-        }
-
-        foreach (var (frameIdx, timeSpent) in frameTimes.OrderByDescending(kv => kv.Value))
-        {
-            var name = frameIdx < framesList.Count ? framesList[frameIdx] : "Unknown";
-            frameCounts.TryGetValue(frameIdx, out var calls);
-            allFunctions.Add(new FunctionSample(name, timeSpent, calls, frameIdx));
-        }
-
-        var timeUnitLabel = hasSampleUnit && !hasTimeUnit ? "samples" : "ms";
-        var countLabel = hasSampledProfile ? "Samples" : "Calls";
-        var countSuffix = hasSampledProfile ? " samp" : "x";
-
-        return new CpuProfileResult(
-            allFunctions,
-            totalTime,
-            callTreeRoot,
-            callTreeTotal,
-            speedscopePath,
-            timeUnitLabel,
-            countLabel,
-            countSuffix);
-    }
-
-    private static void ProcessEventedProfile(
-        JsonElement eventsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, double> frameSelfTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale)
-    {
-        var stack = new List<(CallTreeNode Node, double Start, int FrameIdx)>();
-        var hasLast = false;
-        var lastAt = 0d;
-
-        foreach (var evt in eventsElement.EnumerateArray())
-        {
-            if (!evt.TryGetProperty("type", out var typeElement) ||
-                typeElement.ValueKind != JsonValueKind.String)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("frame", out var frameElement) ||
-                frameElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            if (!evt.TryGetProperty("at", out var atElement) ||
-                atElement.ValueKind != JsonValueKind.Number)
-            {
-                continue;
-            }
-
-            var eventType = typeElement.GetString();
-            var frameIdx = frameElement.GetInt32();
-            var at = atElement.GetDouble() * timeScale;
-
-            if (hasLast && stack.Count > 0)
-            {
-                var topIdx = stack[^1].FrameIdx;
-                frameSelfTimes.TryGetValue(topIdx, out var selfTime);
-                var delta = at - lastAt;
-                frameSelfTimes[topIdx] = selfTime + delta;
-                stack[^1].Node.Self += delta;
-            }
-
-            hasLast = true;
-            lastAt = at;
-
-            if (string.Equals(eventType, "O", StringComparison.Ordinal))
-            {
-                var parentNode = stack.Count > 0 ? stack[^1].Node : callTreeRoot;
-                var childNode = GetOrCreateCallTreeChild(parentNode, frameIdx, framesList);
-                childNode.Calls += 1;
-                stack.Add((childNode, at, frameIdx));
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + 1;
-            }
-            else if (string.Equals(eventType, "C", StringComparison.Ordinal))
-            {
-                if (stack.Count > 0 && stack[^1].FrameIdx == frameIdx)
-                {
-                    var (node, openTime, _) = stack[^1];
-                    stack.RemoveAt(stack.Count - 1);
-                    var duration = at - openTime;
-                    frameTimes.TryGetValue(frameIdx, out var time);
-                    frameTimes[frameIdx] = time + duration;
-                    node.Total += duration;
-                    node.UpdateTiming(openTime, at);
-                    if (stack.Count == 0)
-                    {
-                        callTreeTotal += duration;
-                    }
-                }
-            }
-        }
-    }
-
-    private static void ProcessSampledProfile(
-        JsonElement samplesElement,
-        JsonElement? weightsElement,
-        IReadOnlyList<string> framesList,
-        CallTreeNode callTreeRoot,
-        Dictionary<int, double> frameTimes,
-        Dictionary<int, int> frameCounts,
-        ref double callTreeTotal,
-        double timeScale,
-        bool isSampleUnit)
-    {
-        var hasWeights = weightsElement.HasValue &&
-                         weightsElement.Value.ValueKind == JsonValueKind.Array;
-        var weightsArray = weightsElement.GetValueOrDefault();
-        var sampleIndex = 0;
-
-        foreach (var sample in samplesElement.EnumerateArray())
-        {
-            if (sample.ValueKind != JsonValueKind.Array)
-            {
-                sampleIndex++;
-                continue;
-            }
-
-            var weight = 1d;
-            if (hasWeights && sampleIndex < weightsArray.GetArrayLength())
-            {
-                var weightElement = weightsArray[sampleIndex];
-                if (weightElement.ValueKind == JsonValueKind.Number)
-                {
-                    weight = weightElement.GetDouble();
-                }
-            }
-
-            var timeWeight = weight * timeScale;
-            var callWeight = 1;
-            if (isSampleUnit)
-            {
-                callWeight = weight <= 0
-                    ? 0
-                    : Math.Max(1, (int)Math.Round(weight));
-            }
-
-            var current = callTreeRoot;
-            var hasFrame = false;
-            foreach (var frameIdxElement in sample.EnumerateArray())
-            {
-                if (frameIdxElement.ValueKind != JsonValueKind.Number)
-                {
-                    continue;
-                }
-
-                var frameIdx = frameIdxElement.GetInt32();
-                if (frameIdx < 0)
-                {
-                    continue;
-                }
-
-                hasFrame = true;
-                var child = GetOrCreateCallTreeChild(current, frameIdx, framesList);
-                child.Total += timeWeight;
-                child.Calls += callWeight;
-                frameTimes.TryGetValue(frameIdx, out var time);
-                frameTimes[frameIdx] = time + timeWeight;
-                frameCounts.TryGetValue(frameIdx, out var count);
-                frameCounts[frameIdx] = count + callWeight;
-                current = child;
-            }
-
-            if (hasFrame)
-            {
-                current.Self += timeWeight;
-                callTreeTotal += timeWeight;
-            }
-
-            sampleIndex++;
-        }
-    }
-
-    private static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
-    {
-        if (!profile.TryGetProperty("unit", out var unitElement) ||
-            unitElement.ValueKind != JsonValueKind.String)
-        {
-            return (1d, false);
-        }
-
-        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
-        return unit switch
-        {
-            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
-            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
-            "milliseconds" or "millisecond" or "ms" => (1d, false),
-            "seconds" or "second" or "s" => (1_000d, false),
-            "samples" or "sample" => (1d, true),
-            _ => (1d, false)
-        };
-    }
-
-    private static CallTreeNode GetOrCreateCallTreeChild(
-        CallTreeNode parent,
-        int frameIdx,
-        IReadOnlyList<string> frames)
-    {
-        if (!parent.Children.TryGetValue(frameIdx, out var child))
-        {
-            var name = frameIdx >= 0 && frameIdx < frames.Count ? frames[frameIdx] : "Unknown";
-            child = new CallTreeNode(frameIdx, name);
-            parent.Children[frameIdx] = child;
-        }
-
-        return child;
-    }
-
-    private static double SumCallTreeTotals(CallTreeNode node)
-    {
-        var sum = 0d;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Total;
-        }
-        return sum;
-    }
-
-    private static int SumCallTreeCalls(CallTreeNode node)
-    {
-        var sum = 0;
-        foreach (var child in node.Children.Values)
-        {
-            sum += child.Calls;
-        }
-        return sum;
+        frames = names;
+        return true;
     }
 }

--- a/src/ProfileTool/Cpu/SpeedscopeProfileAccumulator.cs
+++ b/src/ProfileTool/Cpu/SpeedscopeProfileAccumulator.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Asynkron.Profiler;
+
+internal sealed class SpeedscopeProfileAccumulator
+{
+    private readonly IReadOnlyList<string> _frames;
+    private readonly Dictionary<int, double> _frameTimes = [];
+    private readonly Dictionary<int, int> _frameCounts = [];
+    private readonly CallTreeNode _callTreeRoot = new(-1, "Total");
+
+    private double _callTreeTotal;
+    private bool _hasSampledProfile;
+    private bool _hasSampleUnit;
+    private bool _hasTimeUnit;
+    private int _parsedProfiles;
+
+    public SpeedscopeProfileAccumulator(IReadOnlyList<string> frames)
+    {
+        _frames = frames;
+    }
+
+    public void AddProfile(JsonElement profile)
+    {
+        var (timeScale, isSampleUnit) = GetUnitScale(profile);
+        if (SpeedscopeJsonElementHelper.TryGetArray(profile, "events", out var eventsElement))
+        {
+            _parsedProfiles++;
+            _hasTimeUnit = true;
+            ProcessEventedProfile(eventsElement, timeScale);
+            return;
+        }
+
+        if (SpeedscopeJsonElementHelper.TryGetArray(profile, "samples", out var samplesElement))
+        {
+            _parsedProfiles++;
+            _hasSampledProfile = true;
+            if (isSampleUnit)
+            {
+                _hasSampleUnit = true;
+            }
+            else
+            {
+                _hasTimeUnit = true;
+            }
+
+            ProcessSampledProfile(
+                samplesElement,
+                SpeedscopeJsonElementHelper.GetOptionalArray(profile, "weights"),
+                timeScale,
+                isSampleUnit);
+        }
+    }
+
+    public CpuProfileResult? BuildResult(string? speedscopePath)
+    {
+        if (_parsedProfiles == 0)
+        {
+            return null;
+        }
+
+        var totalTime = _frameTimes.Values.Sum();
+        if (_callTreeTotal <= 0)
+        {
+            _callTreeTotal = SumNodeTotals(_callTreeRoot);
+        }
+
+        _callTreeRoot.Total = _callTreeTotal;
+        _callTreeRoot.Calls = SumNodeCalls(_callTreeRoot);
+        UpdateRootTiming();
+
+        var timeUnitLabel = _hasSampleUnit && !_hasTimeUnit ? "samples" : "ms";
+        var countLabel = _hasSampledProfile ? "Samples" : "Calls";
+        var countSuffix = _hasSampledProfile ? " samp" : "x";
+
+        return new CpuProfileResult(
+            BuildFunctionSamples(),
+            totalTime,
+            _callTreeRoot,
+            _callTreeTotal,
+            speedscopePath,
+            timeUnitLabel,
+            countLabel,
+            countSuffix);
+    }
+
+    private void ProcessEventedProfile(JsonElement eventsElement, double timeScale)
+    {
+        var stack = new List<(CallTreeNode Node, double Start, int FrameIdx)>();
+        var hasLast = false;
+        var lastAt = 0d;
+
+        foreach (var evt in eventsElement.EnumerateArray())
+        {
+            if (!TryReadEvent(evt, out var eventType, out var frameIdx, out var at, timeScale))
+            {
+                continue;
+            }
+
+            if (hasLast && stack.Count > 0)
+            {
+                var delta = at - lastAt;
+                stack[^1].Node.Self += delta;
+            }
+
+            hasLast = true;
+            lastAt = at;
+
+            if (string.Equals(eventType, "O", StringComparison.Ordinal))
+            {
+                var parentNode = stack.Count > 0 ? stack[^1].Node : _callTreeRoot;
+                var childNode = GetOrCreateCallTreeChild(parentNode, frameIdx);
+                childNode.Calls += 1;
+                _frameCounts[frameIdx] = _frameCounts.GetValueOrDefault(frameIdx) + 1;
+                stack.Add((childNode, at, frameIdx));
+                continue;
+            }
+
+            if (string.Equals(eventType, "C", StringComparison.Ordinal) &&
+                stack.Count > 0 &&
+                stack[^1].FrameIdx == frameIdx)
+            {
+                var (node, openTime, _) = stack[^1];
+                stack.RemoveAt(stack.Count - 1);
+                var duration = at - openTime;
+                _frameTimes[frameIdx] = _frameTimes.GetValueOrDefault(frameIdx) + duration;
+                node.Total += duration;
+                node.UpdateTiming(openTime, at);
+                if (stack.Count == 0)
+                {
+                    _callTreeTotal += duration;
+                }
+            }
+        }
+    }
+
+    private void ProcessSampledProfile(
+        JsonElement samplesElement,
+        JsonElement? weightsElement,
+        double timeScale,
+        bool isSampleUnit)
+    {
+        var hasWeights = weightsElement.HasValue &&
+                         weightsElement.Value.ValueKind == JsonValueKind.Array;
+        var weightsArray = weightsElement.GetValueOrDefault();
+        var sampleIndex = 0;
+
+        foreach (var sample in samplesElement.EnumerateArray())
+        {
+            if (sample.ValueKind != JsonValueKind.Array)
+            {
+                sampleIndex++;
+                continue;
+            }
+
+            var weight = GetSampleWeight(weightsArray, hasWeights, sampleIndex);
+            var timeWeight = weight * timeScale;
+            var callWeight = GetCallWeight(weight, isSampleUnit);
+
+            var current = _callTreeRoot;
+            var hasFrame = false;
+            foreach (var frameIdxElement in sample.EnumerateArray())
+            {
+                if (frameIdxElement.ValueKind != JsonValueKind.Number)
+                {
+                    continue;
+                }
+
+                var frameIdx = frameIdxElement.GetInt32();
+                if (frameIdx < 0)
+                {
+                    continue;
+                }
+
+                hasFrame = true;
+                var child = GetOrCreateCallTreeChild(current, frameIdx);
+                child.Total += timeWeight;
+                child.Calls += callWeight;
+                _frameTimes[frameIdx] = _frameTimes.GetValueOrDefault(frameIdx) + timeWeight;
+                _frameCounts[frameIdx] = _frameCounts.GetValueOrDefault(frameIdx) + callWeight;
+                current = child;
+            }
+
+            if (hasFrame)
+            {
+                current.Self += timeWeight;
+                _callTreeTotal += timeWeight;
+            }
+
+            sampleIndex++;
+        }
+    }
+
+    private List<FunctionSample> BuildFunctionSamples()
+    {
+        var allFunctions = new List<FunctionSample>();
+        foreach (var (frameIdx, timeSpent) in _frameTimes.OrderByDescending(entry => entry.Value))
+        {
+            var name = frameIdx < _frames.Count ? _frames[frameIdx] : "Unknown";
+            _frameCounts.TryGetValue(frameIdx, out var calls);
+            allFunctions.Add(new FunctionSample(name, timeSpent, calls, frameIdx));
+        }
+
+        return allFunctions;
+    }
+
+    private void UpdateRootTiming()
+    {
+        foreach (var child in _callTreeRoot.Children.Values)
+        {
+            if (child.HasTiming)
+            {
+                _callTreeRoot.UpdateTiming(child.MinStart, child.MaxEnd);
+            }
+        }
+    }
+
+    private CallTreeNode GetOrCreateCallTreeChild(CallTreeNode parent, int frameIdx)
+    {
+        if (!parent.Children.TryGetValue(frameIdx, out var child))
+        {
+            var name = frameIdx >= 0 && frameIdx < _frames.Count ? _frames[frameIdx] : "Unknown";
+            child = new CallTreeNode(frameIdx, name);
+            parent.Children[frameIdx] = child;
+        }
+
+        return child;
+    }
+
+    private static bool TryReadEvent(
+        JsonElement evt,
+        out string? eventType,
+        out int frameIdx,
+        out double at,
+        double timeScale)
+    {
+        eventType = null;
+        frameIdx = 0;
+        at = 0d;
+
+        if (!evt.TryGetProperty("type", out var typeElement) ||
+            typeElement.ValueKind != JsonValueKind.String ||
+            !evt.TryGetProperty("frame", out var frameElement) ||
+            frameElement.ValueKind != JsonValueKind.Number ||
+            !evt.TryGetProperty("at", out var atElement) ||
+            atElement.ValueKind != JsonValueKind.Number)
+        {
+            return false;
+        }
+
+        eventType = typeElement.GetString();
+        frameIdx = frameElement.GetInt32();
+        at = atElement.GetDouble() * timeScale;
+        return true;
+    }
+
+    private static double GetSampleWeight(JsonElement weightsArray, bool hasWeights, int sampleIndex)
+    {
+        if (!hasWeights || sampleIndex >= weightsArray.GetArrayLength())
+        {
+            return 1d;
+        }
+
+        var weightElement = weightsArray[sampleIndex];
+        return weightElement.ValueKind == JsonValueKind.Number
+            ? weightElement.GetDouble()
+            : 1d;
+    }
+
+    private static int GetCallWeight(double weight, bool isSampleUnit)
+    {
+        if (!isSampleUnit)
+        {
+            return 1;
+        }
+
+        return weight <= 0
+            ? 0
+            : Math.Max(1, (int)Math.Round(weight));
+    }
+
+    private static (double TimeScale, bool IsSampleUnit) GetUnitScale(JsonElement profile)
+    {
+        if (!profile.TryGetProperty("unit", out var unitElement) ||
+            unitElement.ValueKind != JsonValueKind.String)
+        {
+            return (1d, false);
+        }
+
+        var unit = unitElement.GetString()?.Trim().ToLowerInvariant();
+        return unit switch
+        {
+            "nanoseconds" or "nanosecond" or "ns" => (1d / 1_000_000d, false),
+            "microseconds" or "microsecond" or "us" => (1d / 1_000d, false),
+            "milliseconds" or "millisecond" or "ms" => (1d, false),
+            "seconds" or "second" or "s" => (1_000d, false),
+            "samples" or "sample" => (1d, true),
+            _ => (1d, false)
+        };
+    }
+
+    private static double SumNodeTotals(CallTreeNode node)
+    {
+        var sum = 0d;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Total;
+        }
+
+        return sum;
+    }
+
+    private static int SumNodeCalls(CallTreeNode node)
+    {
+        var sum = 0;
+        foreach (var child in node.Children.Values)
+        {
+            sum += child.Calls;
+        }
+
+        return sum;
+    }
+}

--- a/tests/Asynkron.Profiler.Tests/SpeedscopeParserTests.cs
+++ b/tests/Asynkron.Profiler.Tests/SpeedscopeParserTests.cs
@@ -35,63 +35,36 @@ public sealed class SpeedscopeParserTests
         Assert.Equal("ms", result.TimeUnitLabel);
         Assert.Equal("Calls", result.CountLabel);
         Assert.Equal("x", result.CountSuffix);
-        var root = result.CallTreeRoot;
-        var nodeA = root.Children.Values.Single(node => node.Name == "A");
-        var nodeB = nodeA.Children.Values.Single(node => node.Name == "B");
-        var nodeC = nodeA.Children.Values.Single(node => node.Name == "C");
-
-        Assert.Equal(11d, nodeA.Total, 3);
-        Assert.Equal(2, nodeA.Calls);
-        Assert.Equal(2d, nodeB.Total, 3);
-        Assert.Equal(2d, nodeC.Total, 3);
-
-        var sampleA = result.AllFunctions.Single(sample => sample.Name == "A");
-        var sampleB = result.AllFunctions.Single(sample => sample.Name == "B");
-        var sampleC = result.AllFunctions.Single(sample => sample.Name == "C");
-
-        AssertFunction(sampleA, 11d, 2);
-        AssertFunction(sampleB, 2d, 1);
-        AssertFunction(sampleC, 2d, 1);
+        var nodeA = AssertNode(result.CallTreeRoot, "A", 11d, 2);
+        AssertNode(nodeA, "B", 2d, 1);
+        AssertNode(nodeA, "C", 2d, 1);
+        AssertFunctions(result, ("A", 11d, 2), ("B", 2d, 1), ("C", 2d, 1));
     }
 
     [Fact]
     public void ParsesSampledProfilesWithWeights()
     {
-        var result = Parse(CreateSpeedscopeJson(
-            """
-                {
-                  "type": "sampled",
-                  "unit": "samples",
-                  "samples": [
-                    [0, 1],
-                    [0, 2]
-                  ],
-                  "weights": [2, 1]
-                }
-            """));
+        var result = ParseSampled("samples", "[0, 1],\n                    [0, 2]", "2, 1");
 
         Assert.Equal("samples", result.TimeUnitLabel);
         Assert.Equal("Samples", result.CountLabel);
         Assert.Equal(" samp", result.CountSuffix);
-        var root = result.CallTreeRoot;
-        var nodeA = root.Children.Values.Single(node => node.Name == "A");
-        var nodeB = nodeA.Children.Values.Single(node => node.Name == "B");
-        var nodeC = nodeA.Children.Values.Single(node => node.Name == "C");
+        var nodeA = AssertNode(result.CallTreeRoot, "A", 3d, 3);
+        AssertNode(nodeA, "B", 2d, 2);
+        AssertNode(nodeA, "C", 1d, 1);
+        AssertFunctions(result, ("A", 3d, 3), ("B", 2d, 2), ("C", 1d, 1));
+    }
 
-        Assert.Equal(3d, nodeA.Total, 3);
-        Assert.Equal(3, nodeA.Calls);
-        Assert.Equal(2d, nodeB.Total, 3);
-        Assert.Equal(2, nodeB.Calls);
-        Assert.Equal(1d, nodeC.Total, 3);
-        Assert.Equal(1, nodeC.Calls);
+    [Fact]
+    public void ConvertsTimeBasedSampleWeightsToMilliseconds()
+    {
+        var result = ParseSampled("microseconds", "[0]", "500");
 
-        var sampleA = result.AllFunctions.Single(sample => sample.Name == "A");
-        var sampleB = result.AllFunctions.Single(sample => sample.Name == "B");
-        var sampleC = result.AllFunctions.Single(sample => sample.Name == "C");
+        Assert.Equal("ms", result.TimeUnitLabel);
+        Assert.Equal("Samples", result.CountLabel);
+        Assert.Equal(" samp", result.CountSuffix);
 
-        AssertFunction(sampleA, 3d, 3);
-        AssertFunction(sampleB, 2d, 2);
-        AssertFunction(sampleC, 1d, 1);
+        AssertFunctions(result, ("A", 0.5d, 1));
     }
 
     private static CpuProfileResult Parse(string json)
@@ -99,6 +72,20 @@ public sealed class SpeedscopeParserTests
         var result = SpeedscopeParser.ParseJson(json);
         Assert.NotNull(result);
         return result!;
+    }
+
+    private static CpuProfileResult ParseSampled(string unit, string samplesJson, string weightsJson)
+    {
+        return Parse(CreateSpeedscopeJson($$"""
+            {
+              "type": "sampled",
+              "unit": "{{unit}}",
+              "samples": [
+                {{samplesJson}}
+              ],
+              "weights": [{{weightsJson}}]
+            }
+            """));
     }
 
     private static string CreateSpeedscopeJson(string profilesJson)
@@ -117,6 +104,23 @@ public sealed class SpeedscopeParserTests
               ]
             }
             """;
+    }
+
+    private static CallTreeNode AssertNode(CallTreeNode parent, string name, double expectedTotal, int expectedCalls)
+    {
+        var node = parent.Children.Values.Single(child => child.Name == name);
+        Assert.Equal(expectedTotal, node.Total, 3);
+        Assert.Equal(expectedCalls, node.Calls);
+        return node;
+    }
+
+    private static void AssertFunctions(CpuProfileResult result, params (string Name, double Time, int Calls)[] expectedFunctions)
+    {
+        foreach (var (name, time, calls) in expectedFunctions)
+        {
+            var sample = result.AllFunctions.Single(entry => entry.Name == name);
+            AssertFunction(sample, time, calls);
+        }
     }
 
     private static void AssertFunction(FunctionSample sample, double expectedTime, int expectedCalls)


### PR DESCRIPTION
﻿## Summary
- Split `SpeedscopeParser` so it only handles document/file orchestration and frame extraction.
- Moved mutable profile accumulation and call tree construction into `SpeedscopeProfileAccumulator` to improve separation of concerns.
- Added `SpeedscopeJsonElementHelper` so Speedscope JSON array handling is centralized instead of duplicated.
- Simplified `SpeedscopeParserTests` with shared assertions and added coverage for time-based sampled weights converting to milliseconds.
- Re-ran duplication checks and removed the new duplicate patterns introduced by the refactor.

## Testing
- `dotnet build Asynkron.Profiler.sln -warnaserror`
- `dotnet test Asynkron.Profiler.sln`
- `quickdup -path . -ext .cs -top 20 -exclude ".g.,.generated.,bin,obj"`
- `dotnet format Asynkron.Profiler.sln --verify-no-changes`

## Notes
- I attempted the first `pre-pr` step with `roslynator fix Asynkron.Profiler.sln`, but the installed `roslynator.dotnet.cli` 0.12.0 crashes on this solution with `MissingFieldException: Microsoft.Build.Shared.MSBuildConstants.InvalidPathChars`. The repo itself now verifies cleanly with the warning-as-error build, tests, formatting check, and QuickDup scan above.