### PR TITLE
Refactor call tree rendering responsibilities

### DIFF
--- a/src/ProfilerCore/Rendering/CallTreeTimelineBarRenderer.cs
+++ b/src/ProfilerCore/Rendering/CallTreeTimelineBarRenderer.cs
@@ -1,0 +1,103 @@
+using System;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal static class CallTreeTimelineBarRenderer
+{
+    public static string Render(CallTreeNode node, TimelineContext context)
+    {
+        if (!node.HasTiming || context.RootDuration <= 0)
+        {
+            return new string(' ', context.BarWidth);
+        }
+
+        var buffer = new char[context.BarWidth];
+        Array.Fill(buffer, ' ');
+
+        var startOffset = node.MinStart - context.RootStart;
+        var startRatio = Math.Clamp(startOffset / context.RootDuration, 0, 1);
+        var durationRatio = Math.Clamp((node.MaxEnd - node.MinStart) / context.RootDuration, 0, 1);
+
+        var startPosition = startRatio * context.BarWidth;
+        var endPosition = (startRatio + durationRatio) * context.BarWidth;
+
+        var leftIndex = (int)Math.Floor(startPosition);
+        var rightIndex = (int)Math.Ceiling(endPosition) - 1;
+        leftIndex = Math.Clamp(leftIndex, 0, context.BarWidth - 1);
+        rightIndex = Math.Clamp(rightIndex, 0, context.BarWidth - 1);
+
+        if (rightIndex < leftIndex)
+        {
+            rightIndex = leftIndex;
+        }
+
+        if (leftIndex == rightIndex)
+        {
+            var singleFraction = Math.Clamp(endPosition - startPosition, 0, 1);
+            buffer[leftIndex] = singleFraction switch
+            {
+                >= 0.875 => '█',
+                >= 0.625 => '▊',
+                >= 0.375 => '▌',
+                >= 0.125 => '▎',
+                _ => ' '
+            };
+        }
+        else
+        {
+            var leftFraction = 1 - (startPosition - leftIndex);
+            buffer[leftIndex] = SelectLeftBlock(leftFraction);
+
+            for (var index = leftIndex + 1; index < rightIndex; index++)
+            {
+                buffer[index] = '█';
+            }
+
+            var rightFraction = endPosition - Math.Floor(endPosition);
+            buffer[rightIndex] = rightFraction <= 0 ? '█' : SelectRightBlock(rightFraction);
+        }
+
+        var heat = Math.Clamp((node.MaxEnd - node.MinStart) / context.RootDuration, 0, 1);
+        var color = GetHeatColor(heat);
+        return $"[{color}]{Markup.Escape(new string(buffer))}[/]";
+    }
+
+    private static string GetHeatColor(double percentage)
+    {
+        return percentage switch
+        {
+            >= 0.75 => "red",
+            >= 0.50 => "orange1",
+            >= 0.25 => "yellow1",
+            _ => "grey"
+        };
+    }
+
+    private static char SelectLeftBlock(double fraction)
+    {
+        return fraction switch
+        {
+            >= 1.0 => '█',
+            >= 0.875 => '▉',
+            >= 0.75 => '▊',
+            >= 0.625 => '▋',
+            >= 0.5 => '▌',
+            >= 0.375 => '▍',
+            >= 0.25 => '▎',
+            >= 0.125 => '▏',
+            _ => ' '
+        };
+    }
+
+    private static char SelectRightBlock(double fraction)
+    {
+        return fraction switch
+        {
+            >= 1.0 => '█',
+            >= 0.5 => '▐',
+            >= 0.125 => '▕',
+            _ => ' '
+        };
+    }
+}

--- a/src/ProfilerCore/Rendering/ProfilerCallTreeFormatter.cs
+++ b/src/ProfilerCore/Rendering/ProfilerCallTreeFormatter.cs
@@ -1,24 +1,23 @@
 using System;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using Spectre.Console;
 using static Asynkron.Profiler.CallTreeHelpers;
 
 namespace Asynkron.Profiler;
 
-internal sealed partial class ProfilerCallTreeFormatter
+internal sealed class ProfilerCallTreeFormatter
 {
-    private const double HotnessColorFloor = 0.001d;
-    private const double HotnessColorMid = 0.0025d;
-    private const double HotnessColorMax = 0.4d;
     private const string HotspotMarker = "\U0001F525";
 
     private readonly Theme _theme;
-    private readonly Regex _jitNumberRegex = JitNumberRegex();
+    private readonly ProfilerHotnessColorScale _hotnessColorScale;
+    private readonly ProfilerJitNumberHighlighter _jitNumberHighlighter;
 
     public ProfilerCallTreeFormatter(Theme theme)
     {
         _theme = theme;
+        _hotnessColorScale = new ProfilerHotnessColorScale(theme);
+        _jitNumberHighlighter = new ProfilerJitNumberHighlighter(theme);
     }
 
     public string FormatAllocationCallTreeLine(
@@ -77,7 +76,7 @@ internal sealed partial class ProfilerCallTreeFormatter
 
         var truncatedName = Truncate(displayName, maxNameLength);
         var hotness = ComputeHotness(node, totalTime, totalSamples);
-        var nameColor = useHeatColor ? GetHotnessColor(hotness) : null;
+        var nameColor = useHeatColor ? _hotnessColorScale.GetColor(hotness) : null;
         var nameText = FormatCallTreeName(truncatedName, matchName, ShouldStopAtLeaf(matchName), nameColor);
 
         var visibleLength = statsLength + truncatedName.Length;
@@ -110,7 +109,7 @@ internal sealed partial class ProfilerCallTreeFormatter
         var pctText = pct.ToString("F1", CultureInfo.InvariantCulture);
         var countText = node.Calls.ToString("N0", CultureInfo.InvariantCulture) + countSuffix;
         var hotness = ComputeHotness(node, totalTime, totalSamples);
-        var nameColor = useHeatColor ? GetHotnessColor(hotness) : null;
+        var nameColor = useHeatColor ? _hotnessColorScale.GetColor(hotness) : null;
 
         var maxNameLength = timeline != null
             ? Math.Max(15, timeline.TextWidth - depth * 4 - $"{timeText} {timeUnitLabel} {pctText}% {countText} ".Length)
@@ -128,7 +127,7 @@ internal sealed partial class ProfilerCallTreeFormatter
             return baseLine;
         }
 
-        var bar = RenderTimelineBar(node, timeline);
+        var bar = CallTreeTimelineBarRenderer.Render(node, timeline);
         var visibleLength = EstimateVisibleLength(baseLine);
         var padding = timeline.GetPaddingForDepth(depth, visibleLength);
         return $"{baseLine}{new string(' ', padding)} [dim]│[/] {bar}";
@@ -171,68 +170,8 @@ internal sealed partial class ProfilerCallTreeFormatter
 
     public string HighlightJitNumbers(string text)
     {
-        return _jitNumberRegex.Replace(text, match => WrapAnsi(match.Value, _theme.AccentColor));
+        return _jitNumberHighlighter.Highlight(text);
     }
-
-    public static string RenderTimelineBar(CallTreeNode node, TimelineContext context)
-    {
-        if (!node.HasTiming || context.RootDuration <= 0)
-        {
-            return new string(' ', context.BarWidth);
-        }
-
-        var buffer = new char[context.BarWidth];
-        Array.Fill(buffer, ' ');
-
-        var startOffset = node.MinStart - context.RootStart;
-        var startRatio = Math.Clamp(startOffset / context.RootDuration, 0, 1);
-        var durationRatio = Math.Clamp((node.MaxEnd - node.MinStart) / context.RootDuration, 0, 1);
-
-        var startPosition = startRatio * context.BarWidth;
-        var endPosition = (startRatio + durationRatio) * context.BarWidth;
-
-        var leftIndex = (int)Math.Floor(startPosition);
-        var rightIndex = (int)Math.Ceiling(endPosition) - 1;
-        leftIndex = Math.Clamp(leftIndex, 0, context.BarWidth - 1);
-        rightIndex = Math.Clamp(rightIndex, 0, context.BarWidth - 1);
-
-        if (rightIndex < leftIndex)
-        {
-            rightIndex = leftIndex;
-        }
-
-        if (leftIndex == rightIndex)
-        {
-            var singleFraction = Math.Clamp(endPosition - startPosition, 0, 1);
-            buffer[leftIndex] = singleFraction switch
-            {
-                >= 0.875 => '█',
-                >= 0.625 => '▊',
-                >= 0.375 => '▌',
-                >= 0.125 => '▎',
-                _ => ' '
-            };
-        }
-        else
-        {
-            var leftFraction = 1 - (startPosition - leftIndex);
-            buffer[leftIndex] = SelectLeftBlock(leftFraction);
-
-            for (var index = leftIndex + 1; index < rightIndex; index++)
-            {
-                buffer[index] = '█';
-            }
-
-            var rightFraction = endPosition - Math.Floor(endPosition);
-            buffer[rightIndex] = rightFraction <= 0 ? '█' : SelectRightBlock(rightFraction);
-        }
-
-        var heat = Math.Clamp((node.MaxEnd - node.MinStart) / context.RootDuration, 0, 1);
-        var color = GetHeatColor(heat);
-        return $"[{color}]{Markup.Escape(new string(buffer))}[/]";
-    }
-
-    public static bool IsFireEmojiCandidate(double hotness, double hotThreshold) => hotness >= hotThreshold;
 
     private static double GetDisplayedTime(CallTreeNode node, bool useSelfTime, bool isRoot)
     {
@@ -268,16 +207,6 @@ internal sealed partial class ProfilerCallTreeFormatter
         return value.Length > maxLength ? value[..(maxLength - 3)] + "..." : value;
     }
 
-    private static string WrapAnsi(string text, string? color)
-    {
-        if (string.IsNullOrWhiteSpace(color))
-        {
-            return text;
-        }
-
-        return $"[{color}]{Markup.Escape(text)}[/]";
-    }
-
     private static int EstimateVisibleLength(string markup)
     {
         var result = markup;
@@ -300,90 +229,4 @@ internal sealed partial class ProfilerCallTreeFormatter
 
         return result.Length;
     }
-
-    private string? GetHotnessColor(double hotness)
-    {
-        if (!ConsoleThemeHelpers.TryParseHexColor(_theme.TextColor, out var cool) ||
-            !ConsoleThemeHelpers.TryParseHexColor(_theme.HotColor, out var hot))
-        {
-            return null;
-        }
-
-        double normalizedHotness;
-        if (hotness <= HotnessColorFloor)
-        {
-            normalizedHotness = 0d;
-        }
-        else if (hotness <= HotnessColorMid)
-        {
-            var span = HotnessColorMid - HotnessColorFloor;
-            normalizedHotness = span > 0d
-                ? (hotness - HotnessColorFloor) / span * 0.5d
-                : 0d;
-        }
-        else if (hotness >= HotnessColorMax)
-        {
-            normalizedHotness = 1d;
-        }
-        else
-        {
-            var span = HotnessColorMax - HotnessColorMid;
-            normalizedHotness = span > 0d
-                ? 0.5d + (hotness - HotnessColorMid) / span * 0.5d
-                : 1d;
-        }
-
-        normalizedHotness = Math.Clamp(normalizedHotness, 0d, 1d);
-        return InterpolateColor(cool, hot, normalizedHotness);
-    }
-
-    private static string InterpolateColor((byte R, byte G, byte B) start, (byte R, byte G, byte B) end, double t)
-    {
-        t = Math.Clamp(t, 0d, 1d);
-        var r = (byte)Math.Round(start.R + (end.R - start.R) * t);
-        var g = (byte)Math.Round(start.G + (end.G - start.G) * t);
-        var b = (byte)Math.Round(start.B + (end.B - start.B) * t);
-        return $"#{r:X2}{g:X2}{b:X2}";
-    }
-
-    private static string GetHeatColor(double percentage)
-    {
-        return percentage switch
-        {
-            >= 0.75 => "red",
-            >= 0.50 => "orange1",
-            >= 0.25 => "yellow1",
-            _ => "grey"
-        };
-    }
-
-    private static char SelectLeftBlock(double fraction)
-    {
-        return fraction switch
-        {
-            >= 1.0 => '█',
-            >= 0.875 => '▉',
-            >= 0.75 => '▊',
-            >= 0.625 => '▋',
-            >= 0.5 => '▌',
-            >= 0.375 => '▍',
-            >= 0.25 => '▎',
-            >= 0.125 => '▏',
-            _ => ' '
-        };
-    }
-
-    private static char SelectRightBlock(double fraction)
-    {
-        return fraction switch
-        {
-            >= 1.0 => '█',
-            >= 0.5 => '▐',
-            >= 0.125 => '▕',
-            _ => ' '
-        };
-    }
-
-    [GeneratedRegex(@"(?<![A-Za-z0-9_])(#?0x[0-9A-Fa-f]+|#?\d+)(?![A-Za-z0-9_])", RegexOptions.Compiled)]
-    private static partial Regex JitNumberRegex();
 }

--- a/src/ProfilerCore/Rendering/ProfilerCallTreeRenderer.cs
+++ b/src/ProfilerCore/Rendering/ProfilerCallTreeRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 using static Asynkron.Profiler.CallTreeHelpers;
@@ -17,6 +16,7 @@ internal sealed class ProfilerCallTreeRenderer
     private readonly ProfilerCallTreeNodeDecorator _nodeDecorator;
     private readonly ProfilerExceptionTreeRenderer _exceptionRenderer;
     private readonly ProfilerAllocationTreeRenderer _allocationRenderer;
+    private readonly ProfilerTimelineRowsRenderer _timelineRenderer;
 
     public ProfilerCallTreeRenderer(Theme theme, ProfilerCallTreeFormatter formatter)
     {
@@ -27,6 +27,7 @@ internal sealed class ProfilerCallTreeRenderer
         _nodeDecorator = new ProfilerCallTreeNodeDecorator(theme);
         _exceptionRenderer = new ProfilerExceptionTreeRenderer(theme, formatter, _treeFactory);
         _allocationRenderer = new ProfilerAllocationTreeRenderer(formatter, _treeFactory);
+        _timelineRenderer = new ProfilerTimelineRowsRenderer(theme, formatter);
     }
 
     public Rows BuildCpuCallTree(
@@ -69,38 +70,7 @@ internal sealed class ProfilerCallTreeRenderer
 
         if (showTimeline && rootSelection.RootNode.HasTiming)
         {
-            var terminalWidth = Console.WindowWidth > 0 ? Console.WindowWidth : 160;
-            var actualTimelineWidth = Math.Max(20, timelineWidth);
-            var treeColumnWidth = terminalWidth - actualTimelineWidth - 2;
-            var timeline = new TimelineContext
-            {
-                RootStart = rootSelection.RootNode.MinStart,
-                RootEnd = rootSelection.RootNode.MaxEnd,
-                BarWidth = actualTimelineWidth,
-                TextWidth = treeColumnWidth,
-                MaxNameLength = 200,
-                MaxDepth = traversal.MaxDepth
-            };
-
-            var rows = new List<(string TreeText, int VisibleLength, string TimelineBar)>();
-            CollectTimelineRows(
-                rows,
-                rootSelection.RootNode,
-                context,
-                "",
-                true,
-                isHotspot: false,
-                0,
-                timeline);
-
-            var outputLines = new List<IRenderable> { new Markup($"[bold {_theme.AccentColor}]{rootSelection.Title}[/]") };
-            foreach (var (treeText, visibleLength, timelineBar) in rows)
-            {
-                var padding = Math.Max(0, treeColumnWidth - visibleLength);
-                outputLines.Add(new Markup($"{treeText}{new string(' ', padding)}{timelineBar}"));
-            }
-
-            return new Rows(outputLines);
+            return _timelineRenderer.Build(rootSelection.RootNode, rootSelection.Title, context, timelineWidth);
         }
 
         return BuildStandardTreeRows(rootSelection.RootNode, rootSelection.Title, context);
@@ -224,71 +194,6 @@ internal sealed class ProfilerCallTreeRenderer
             tree);
     }
 
-    private void CollectTimelineRows(
-        List<(string TreeText, int VisibleLength, string TimelineBar)> rows,
-        CallTreeNode node,
-        ProfilerCallTreeRenderContext context,
-        string prefix,
-        bool isRoot,
-        bool isHotspot,
-        int depth,
-        TimelineContext timeline,
-        string? continuationPrefix = null,
-        bool stopAfterCurrent = false)
-    {
-        var (treeText, visibleLength) = _formatter.FormatCallTreeLineSimple(
-            node,
-            context.RootTotal,
-            context.TotalSamples,
-            context.UseSelfTime,
-            isRoot,
-            context.TimeUnitLabel,
-            context.CountSuffix,
-            prefix,
-            timeline.TextWidth,
-            isHotspot,
-            useHeatColor: true);
-        var timelineBar = ProfilerCallTreeFormatter.RenderTimelineBar(node, timeline);
-        rows.Add((treeText, visibleLength, timelineBar));
-
-        if (stopAfterCurrent || depth >= context.Traversal.MaxDepth)
-        {
-            return;
-        }
-
-        var basePrefix = continuationPrefix ?? prefix;
-        var children = CallTreeFilters.GetVisibleChildren(
-            node,
-            context.IncludeRuntime,
-            context.UseSelfTime,
-            context.Traversal.MaxWidth,
-            context.Traversal.SiblingCutoffPercent,
-            CallTreeHelpers.IsRuntimeNoise);
-
-        for (var index = 0; index < children.Count; index++)
-        {
-            var child = children[index];
-            var isLast = index == children.Count - 1;
-            var isSpecialLeaf = ShouldStopAtLeaf(GetCallTreeMatchName(child));
-            var childHotness = ComputeHotness(child, context.RootTotal, context.TotalSamples);
-            var isChildHotspot = context.HighlightHotspots && ProfilerCallTreeFormatter.IsFireEmojiCandidate(childHotness, context.HotThreshold);
-            var connector = isLast ? "└─ " : "├─ ";
-            var continuation = isLast ? "   " : "│  ";
-
-            CollectTimelineRows(
-                rows,
-                child,
-                context,
-                basePrefix + connector,
-                isRoot: false,
-                isHotspot: isChildHotspot,
-                depth + 1,
-                timeline,
-                basePrefix + continuation,
-                isSpecialLeaf);
-        }
-    }
-
     private void AddCallTreeChildren(
         IHasTreeNodes parent,
         CallTreeNode node,
@@ -312,7 +217,7 @@ internal sealed class ProfilerCallTreeRenderer
         foreach (var child in children)
         {
             var childHotness = ComputeHotness(child, context.RootTotal, context.TotalSamples);
-            var isHotspot = context.HighlightHotspots && ProfilerCallTreeFormatter.IsFireEmojiCandidate(childHotness, context.HotThreshold);
+            var isHotspot = context.HighlightHotspots && ProfilerHotnessColorScale.IsHotspot(childHotness, context.HotThreshold);
             var (childNode, isSpecialLeaf) = AddCallTreeChildNode(
                 parent,
                 child,

--- a/src/ProfilerCore/Rendering/ProfilerHotnessColorScale.cs
+++ b/src/ProfilerCore/Rendering/ProfilerHotnessColorScale.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfilerHotnessColorScale
+{
+    private const double HotnessColorFloor = 0.001d;
+    private const double HotnessColorMid = 0.0025d;
+    private const double HotnessColorMax = 0.4d;
+
+    private readonly Theme _theme;
+
+    public ProfilerHotnessColorScale(Theme theme)
+    {
+        _theme = theme;
+    }
+
+    public string? GetColor(double hotness)
+    {
+        if (!ConsoleThemeHelpers.TryParseHexColor(_theme.TextColor, out var cool) ||
+            !ConsoleThemeHelpers.TryParseHexColor(_theme.HotColor, out var hot))
+        {
+            return null;
+        }
+
+        var normalizedHotness = Normalize(hotness);
+        return InterpolateColor(cool, hot, normalizedHotness);
+    }
+
+    public static bool IsHotspot(double hotness, double hotThreshold) => hotness >= hotThreshold;
+
+    private static double Normalize(double hotness)
+    {
+        if (hotness <= HotnessColorFloor)
+        {
+            return 0d;
+        }
+
+        if (hotness <= HotnessColorMid)
+        {
+            var span = HotnessColorMid - HotnessColorFloor;
+            return span > 0d
+                ? (hotness - HotnessColorFloor) / span * 0.5d
+                : 0d;
+        }
+
+        if (hotness >= HotnessColorMax)
+        {
+            return 1d;
+        }
+
+        var upperSpan = HotnessColorMax - HotnessColorMid;
+        return upperSpan > 0d
+            ? 0.5d + (hotness - HotnessColorMid) / upperSpan * 0.5d
+            : 1d;
+    }
+
+    private static string InterpolateColor((byte R, byte G, byte B) start, (byte R, byte G, byte B) end, double t)
+    {
+        t = Math.Clamp(t, 0d, 1d);
+        var r = (byte)Math.Round(start.R + (end.R - start.R) * t);
+        var g = (byte)Math.Round(start.G + (end.G - start.G) * t);
+        var b = (byte)Math.Round(start.B + (end.B - start.B) * t);
+        return $"#{r:X2}{g:X2}{b:X2}";
+    }
+}

--- a/src/ProfilerCore/Rendering/ProfilerJitNumberHighlighter.cs
+++ b/src/ProfilerCore/Rendering/ProfilerJitNumberHighlighter.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace Asynkron.Profiler;
+
+internal sealed partial class ProfilerJitNumberHighlighter
+{
+    private readonly Theme _theme;
+
+    public ProfilerJitNumberHighlighter(Theme theme)
+    {
+        _theme = theme;
+    }
+
+    public string Highlight(string text)
+    {
+        return JitNumberRegex().Replace(text, match => WrapMarkup(match.Value, _theme.AccentColor));
+    }
+
+    private static string WrapMarkup(string text, string? color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            return text;
+        }
+
+        return $"[{color}]{Markup.Escape(text)}[/]";
+    }
+
+    [GeneratedRegex(@"(?<![A-Za-z0-9_])(#?0x[0-9A-Fa-f]+|#?\d+)(?![A-Za-z0-9_])", RegexOptions.Compiled)]
+    private static partial Regex JitNumberRegex();
+}

--- a/src/ProfilerCore/Rendering/ProfilerTimelineRowsRenderer.cs
+++ b/src/ProfilerCore/Rendering/ProfilerTimelineRowsRenderer.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using static Asynkron.Profiler.CallTreeHelpers;
+
+namespace Asynkron.Profiler;
+
+internal sealed class ProfilerTimelineRowsRenderer
+{
+    private readonly Theme _theme;
+    private readonly ProfilerCallTreeFormatter _formatter;
+
+    public ProfilerTimelineRowsRenderer(Theme theme, ProfilerCallTreeFormatter formatter)
+    {
+        _theme = theme;
+        _formatter = formatter;
+    }
+
+    public Rows Build(
+        CallTreeNode rootNode,
+        string title,
+        ProfilerCallTreeRenderContext context,
+        int timelineWidth)
+    {
+        var terminalWidth = Console.WindowWidth > 0 ? Console.WindowWidth : 160;
+        var actualTimelineWidth = Math.Max(20, timelineWidth);
+        var treeColumnWidth = terminalWidth - actualTimelineWidth - 2;
+        var timeline = new TimelineContext
+        {
+            RootStart = rootNode.MinStart,
+            RootEnd = rootNode.MaxEnd,
+            BarWidth = actualTimelineWidth,
+            TextWidth = treeColumnWidth,
+            MaxNameLength = 200,
+            MaxDepth = context.Traversal.MaxDepth
+        };
+
+        var rows = new List<(string TreeText, int VisibleLength, string TimelineBar)>();
+        CollectRows(
+            rows,
+            rootNode,
+            context,
+            prefix: string.Empty,
+            isRoot: true,
+            isHotspot: false,
+            depth: 0,
+            timeline);
+
+        var outputLines = new List<IRenderable> { new Markup($"[bold {_theme.AccentColor}]{title}[/]") };
+        foreach (var (treeText, visibleLength, timelineBar) in rows)
+        {
+            var padding = Math.Max(0, treeColumnWidth - visibleLength);
+            outputLines.Add(new Markup($"{treeText}{new string(' ', padding)}{timelineBar}"));
+        }
+
+        return new Rows(outputLines);
+    }
+
+    private void CollectRows(
+        List<(string TreeText, int VisibleLength, string TimelineBar)> rows,
+        CallTreeNode node,
+        ProfilerCallTreeRenderContext context,
+        string prefix,
+        bool isRoot,
+        bool isHotspot,
+        int depth,
+        TimelineContext timeline,
+        string? continuationPrefix = null,
+        bool stopAfterCurrent = false)
+    {
+        var (treeText, visibleLength) = _formatter.FormatCallTreeLineSimple(
+            node,
+            context.RootTotal,
+            context.TotalSamples,
+            context.UseSelfTime,
+            isRoot,
+            context.TimeUnitLabel,
+            context.CountSuffix,
+            prefix,
+            timeline.TextWidth,
+            isHotspot,
+            useHeatColor: true);
+        var timelineBar = CallTreeTimelineBarRenderer.Render(node, timeline);
+        rows.Add((treeText, visibleLength, timelineBar));
+
+        if (stopAfterCurrent || depth >= context.Traversal.MaxDepth)
+        {
+            return;
+        }
+
+        var basePrefix = continuationPrefix ?? prefix;
+        var children = CallTreeFilters.GetVisibleChildren(
+            node,
+            context.IncludeRuntime,
+            context.UseSelfTime,
+            context.Traversal.MaxWidth,
+            context.Traversal.SiblingCutoffPercent,
+            CallTreeHelpers.IsRuntimeNoise);
+
+        for (var index = 0; index < children.Count; index++)
+        {
+            var child = children[index];
+            var isLast = index == children.Count - 1;
+            var isSpecialLeaf = ShouldStopAtLeaf(GetCallTreeMatchName(child));
+            var childHotness = ComputeHotness(child, context.RootTotal, context.TotalSamples);
+            var isChildHotspot = context.HighlightHotspots &&
+                                 ProfilerHotnessColorScale.IsHotspot(childHotness, context.HotThreshold);
+            var connector = isLast ? "└─ " : "├─ ";
+            var continuation = isLast ? "   " : "│  ";
+
+            CollectRows(
+                rows,
+                child,
+                context,
+                basePrefix + connector,
+                isRoot: false,
+                isHotspot: isChildHotspot,
+                depth + 1,
+                timeline,
+                basePrefix + continuation,
+                isSpecialLeaf);
+        }
+    }
+}

--- a/tests/Asynkron.Profiler.Tests/ProfilerJitNumberHighlighterTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfilerJitNumberHighlighterTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class ProfilerJitNumberHighlighterTests
+{
+    [Fact]
+    public void HighlightWrapsDecimalAndHexTokensWithAccentColor()
+    {
+        var renderer = new ProfilerConsoleRenderer(new Theme { AccentColor = "gold1" });
+
+        var highlighted = renderer.HighlightJitNumbers("mov eax, 42 ; addr 0x1234");
+
+        Assert.Equal("mov eax, [gold1]42[/] ; addr [gold1]0x1234[/]", highlighted);
+    }
+
+    [Fact]
+    public void HighlightLeavesEmbeddedIdentifiersUntouched()
+    {
+        var renderer = new ProfilerConsoleRenderer(new Theme { AccentColor = "gold1" });
+
+        var highlighted = renderer.HighlightJitNumbers("LBB0_4 keeps label0x10 intact");
+
+        Assert.Equal("LBB0_4 keeps label0x10 intact", highlighted);
+    }
+}


### PR DESCRIPTION
﻿## Summary
- extract timeline bar rendering into `CallTreeTimelineBarRenderer`
- extract hotness color interpolation into `ProfilerHotnessColorScale`
- extract JIT number highlighting into `ProfilerJitNumberHighlighter`
- extract timeline row construction into `ProfilerTimelineRowsRenderer`
- slim down `ProfilerCallTreeFormatter` and `ProfilerCallTreeRenderer` so they focus on call-tree formatting/orchestration instead of mixed helper logic
- add a regression test for public JIT highlighting behavior

## Testing
- `roslynator fix src/ProfilerCore/Asynkron.Profiler.Core.csproj`
- `roslynator fix src/ProfileTool/ProfileTool.csproj`
- `roslynator fix tests/Asynkron.Profiler.Tests/Asynkron.Profiler.Tests.csproj`
- `quickdup -path . -ext .cs -select 0..20 -min 2 -exclude ".g.,.generated."`
- `dotnet format Asynkron.Profiler.sln`
- `dotnet build Asynkron.Profiler.sln`
- `dotnet test Asynkron.Profiler.sln`