### PR TITLE
Refactor profile input loading responsibilities

### DIFF
--- a/src/ProfileTool/MemoryProfileResultFactory.cs
+++ b/src/ProfileTool/MemoryProfileResultFactory.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using static Asynkron.Profiler.CallTreeHelpers;
+
+namespace Asynkron.Profiler;
+
+internal static class MemoryProfileResultFactory
+{
+    public static MemoryProfileResult Build(AllocationCallTreeResult callTree)
+    {
+        var allocationEntries = callTree.TypeRoots
+            .OrderByDescending(root => root.TotalBytes)
+            .Take(50)
+            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
+            .ToList();
+
+        var totalAllocated = FormatBytes(callTree.TotalBytes);
+
+        return new MemoryProfileResult(
+            null,
+            null,
+            null,
+            totalAllocated,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            totalAllocated,
+            allocationEntries,
+            callTree,
+            null,
+            null);
+    }
+}

--- a/src/ProfileTool/ProfileCollectionRunner.cs
+++ b/src/ProfileTool/ProfileCollectionRunner.cs
@@ -92,7 +92,7 @@ internal sealed class ProfileCollectionRunner
             },
             _profileInputLoader.AnalyzeAllocationTrace);
 
-        return callTree == null ? null : ProfileInputLoader.BuildMemoryProfileResult(callTree);
+        return callTree == null ? null : MemoryProfileResultFactory.Build(callTree);
     }
 
     public ExceptionProfileResult? RunExceptionProfile(string[] command, string label)

--- a/src/ProfileTool/ProfileInputKind.cs
+++ b/src/ProfileTool/ProfileInputKind.cs
@@ -1,0 +1,11 @@
+namespace Asynkron.Profiler;
+
+internal enum ProfileInputKind
+{
+    Unknown,
+    Speedscope,
+    NetTrace,
+    Etlx,
+    Gcdump,
+    HeapReport
+}

--- a/src/ProfileTool/ProfileInputLoader.cs
+++ b/src/ProfileTool/ProfileInputLoader.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using Spectre.Console;
-using static Asynkron.Profiler.CallTreeHelpers;
 
 namespace Asynkron.Profiler;
 
@@ -43,19 +40,12 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".json")
+        return ProfileInputPath.GetKind(inputPath) switch
         {
-            return AnalyzeSpeedscope(inputPath);
-        }
-
-        if (!IsSupportedExtension(extension, ".nettrace", ".etlx"))
-        {
-            WriteUnsupportedInput("Unsupported CPU input", inputPath);
-            return null;
-        }
-
-        return AnalyzeCpuTrace(inputPath);
+            ProfileInputKind.Speedscope => AnalyzeSpeedscope(inputPath),
+            ProfileInputKind.NetTrace or ProfileInputKind.Etlx => AnalyzeCpuTrace(inputPath),
+            _ => WriteUnsupportedInputAndReturn<CpuProfileResult>("Unsupported CPU input", inputPath)
+        };
     }
 
     public MemoryProfileResult? LoadMemory(string inputPath)
@@ -66,7 +56,7 @@ internal sealed class ProfileInputLoader
         }
 
         var callTree = AnalyzeAllocationTrace(inputPath);
-        return callTree == null ? null : BuildMemoryProfileResult(callTree);
+        return callTree == null ? null : MemoryProfileResultFactory.Build(callTree);
     }
 
     public ExceptionProfileResult? LoadException(string inputPath)
@@ -96,170 +86,49 @@ internal sealed class ProfileInputLoader
             return null;
         }
 
-        var extension = GetNormalizedExtension(inputPath);
-        if (extension == ".gcdump")
+        return ProfileInputPath.GetKind(inputPath) switch
         {
-            if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
-            {
-                return null;
-            }
-
-            return GcdumpReportLoader.Load(
-                inputPath,
-                _getTheme(),
-                _runProcess,
-                _parseGcdumpReport,
-                _writeLine);
-        }
-
-        if (extension is ".txt" or ".log")
-        {
-            return _parseGcdumpReport(File.ReadAllText(inputPath));
-        }
-
-        WriteUnsupportedInput("Unsupported heap input", inputPath);
-        return null;
+            ProfileInputKind.Gcdump => LoadGcdump(inputPath),
+            ProfileInputKind.HeapReport => _parseGcdumpReport(File.ReadAllText(inputPath)),
+            _ => WriteUnsupportedInputAndReturn<HeapProfileResult>("Unsupported heap input", inputPath)
+        };
     }
 
     public CpuProfileResult? AnalyzeCpuTrace(string traceFile)
     {
-        try
+        var result = TryAnalyzeTrace(traceFile, "CPU trace parse failed", _traceAnalyzer.AnalyzeCpuTrace);
+        if (result == null)
         {
-            var result = _traceAnalyzer.AnalyzeCpuTrace(traceFile);
-            if (result.AllFunctions.Count == 0)
-            {
-                _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
-                return null;
-            }
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]CPU trace parse failed:[/] {Markup.Escape(ex.Message)}");
             return null;
         }
+
+        if (result.AllFunctions.Count == 0)
+        {
+            _writeLine($"[{_getTheme().AccentColor}]No CPU samples found in trace.[/]");
+            return null;
+        }
+
+        return result;
     }
 
     public AllocationCallTreeResult? AnalyzeAllocationTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeAllocationTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Allocation trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return TryAnalyzeTrace(traceFile, "Allocation trace parse failed", _traceAnalyzer.AnalyzeAllocationTrace);
     }
 
     public ExceptionProfileResult? AnalyzeExceptionTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeExceptionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Exception trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return TryAnalyzeTrace(traceFile, "Exception trace parse failed", _traceAnalyzer.AnalyzeExceptionTrace);
     }
 
     public ContentionProfileResult? AnalyzeContentionTrace(string traceFile)
     {
-        try
-        {
-            return _traceAnalyzer.AnalyzeContentionTrace(traceFile);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Contention trace parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
-    }
-
-    public static MemoryProfileResult BuildMemoryProfileResult(AllocationCallTreeResult callTree)
-    {
-        var allocationEntries = callTree.TypeRoots
-            .OrderByDescending(root => root.TotalBytes)
-            .Take(50)
-            .Select(root => new AllocationEntry(root.Name, root.Count, FormatBytes(root.TotalBytes)))
-            .ToList();
-
-        var totalAllocated = FormatBytes(callTree.TotalBytes);
-
-        return new MemoryProfileResult(
-            null,
-            null,
-            null,
-            totalAllocated,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            totalAllocated,
-            allocationEntries,
-            callTree,
-            null,
-            null);
-    }
-
-    public static string BuildInputLabel(string inputPath)
-    {
-        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
-    }
-
-    public static void ApplyInputDefaults(
-        string inputPath,
-        ref bool runCpu,
-        ref bool runMemory,
-        ref bool runHeap,
-        ref bool runException,
-        ref bool runContention)
-    {
-        switch (GetNormalizedExtension(inputPath))
-        {
-            case ".json":
-                runCpu = true;
-                break;
-            case ".nettrace":
-                runCpu = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".etlx":
-                runMemory = true;
-                runException = true;
-                runContention = true;
-                break;
-            case ".gcdump":
-            case ".txt":
-            case ".log":
-                runHeap = true;
-                break;
-            default:
-                runCpu = true;
-                break;
-        }
+        return TryAnalyzeTrace(traceFile, "Contention trace parse failed", _traceAnalyzer.AnalyzeContentionTrace);
     }
 
     private CpuProfileResult? AnalyzeSpeedscope(string speedscopePath)
     {
-        try
-        {
-            return ProfilerTraceAnalyzer.AnalyzeSpeedscope(speedscopePath);
-        }
-        catch (Exception ex)
-        {
-            _writeLine($"[{_getTheme().AccentColor}]Speedscope parse failed:[/] {Markup.Escape(ex.Message)}");
-            return null;
-        }
+        return TryAnalyzeTrace(speedscopePath, "Speedscope parse failed", ProfilerTraceAnalyzer.AnalyzeSpeedscope);
     }
 
     private bool TryValidateTraceInput(string inputPath, string unsupportedMessage)
@@ -269,13 +138,28 @@ internal sealed class ProfileInputLoader
             return false;
         }
 
-        if (IsSupportedExtension(GetNormalizedExtension(inputPath), ".nettrace", ".etlx"))
+        if (ProfileInputPath.IsTraceInput(inputPath))
         {
             return true;
         }
 
         WriteUnsupportedInput(unsupportedMessage, inputPath);
         return false;
+    }
+
+    private HeapProfileResult? LoadGcdump(string inputPath)
+    {
+        if (!_ensureToolAvailable("dotnet-gcdump", _dotnetGcdumpInstallHint))
+        {
+            return null;
+        }
+
+        return GcdumpReportLoader.Load(
+            inputPath,
+            _getTheme(),
+            _runProcess,
+            _parseGcdumpReport,
+            _writeLine);
     }
 
     private bool TryEnsureInputExists(string inputPath)
@@ -294,13 +178,24 @@ internal sealed class ProfileInputLoader
         _writeLine($"[{_getTheme().ErrorColor}]{message}:[/] {Markup.Escape(inputPath)}");
     }
 
-    private static string GetNormalizedExtension(string inputPath)
+    private T? TryAnalyzeTrace<T>(string path, string failureMessage, Func<string, T> analyze)
+        where T : class
     {
-        return Path.GetExtension(inputPath).ToLowerInvariant();
+        try
+        {
+            return analyze(path);
+        }
+        catch (Exception ex)
+        {
+            _writeLine($"[{_getTheme().AccentColor}]{failureMessage}[/] {Markup.Escape(ex.Message)}");
+            return null;
+        }
     }
 
-    private static bool IsSupportedExtension(string extension, params string[] allowedExtensions)
+    private T? WriteUnsupportedInputAndReturn<T>(string message, string inputPath)
+        where T : class
     {
-        return allowedExtensions.Contains(extension, StringComparer.Ordinal);
+        WriteUnsupportedInput(message, inputPath);
+        return null;
     }
 }

--- a/src/ProfileTool/ProfileInputPath.cs
+++ b/src/ProfileTool/ProfileInputPath.cs
@@ -1,0 +1,72 @@
+using System.IO;
+
+namespace Asynkron.Profiler;
+
+internal static class ProfileInputPath
+{
+    public static string BuildLabel(string inputPath)
+    {
+        return FileLabelSanitizer.Sanitize(Path.GetFileNameWithoutExtension(inputPath), "input");
+    }
+
+    public static void ApplyDefaults(
+        string inputPath,
+        ref bool runCpu,
+        ref bool runMemory,
+        ref bool runHeap,
+        ref bool runException,
+        ref bool runContention)
+    {
+        switch (GetKind(inputPath))
+        {
+            case ProfileInputKind.Speedscope:
+                runCpu = true;
+                break;
+            case ProfileInputKind.NetTrace:
+                runCpu = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ProfileInputKind.Etlx:
+                runMemory = true;
+                runException = true;
+                runContention = true;
+                break;
+            case ProfileInputKind.Gcdump:
+            case ProfileInputKind.HeapReport:
+                runHeap = true;
+                break;
+            default:
+                runCpu = true;
+                break;
+        }
+    }
+
+    public static bool IsTraceInput(string inputPath)
+    {
+        return IsTraceInput(GetKind(inputPath));
+    }
+
+    public static bool IsTraceInput(ProfileInputKind inputKind)
+    {
+        return inputKind is ProfileInputKind.NetTrace or ProfileInputKind.Etlx;
+    }
+
+    public static ProfileInputKind GetKind(string inputPath)
+    {
+        return GetNormalizedExtension(inputPath) switch
+        {
+            ".json" => ProfileInputKind.Speedscope,
+            ".nettrace" => ProfileInputKind.NetTrace,
+            ".etlx" => ProfileInputKind.Etlx,
+            ".gcdump" => ProfileInputKind.Gcdump,
+            ".txt" or ".log" => ProfileInputKind.HeapReport,
+            _ => ProfileInputKind.Unknown
+        };
+    }
+
+    private static string GetNormalizedExtension(string inputPath)
+    {
+        return Path.GetExtension(inputPath).ToLowerInvariant();
+    }
+}

--- a/src/ProfileTool/ProfilerExecutionRequestFactory.cs
+++ b/src/ProfileTool/ProfilerExecutionRequestFactory.cs
@@ -37,13 +37,13 @@ internal sealed class ProfilerExecutionRequestFactory
 
         if (hasInput)
         {
-            label = ProfileInputLoader.BuildInputLabel(invocation.InputPath!);
+            label = ProfileInputPath.BuildLabel(invocation.InputPath!);
             description = invocation.InputPath!;
             command = Array.Empty<string>();
 
             if (!hasExplicitModes)
             {
-                ProfileInputLoader.ApplyInputDefaults(
+                ProfileInputPath.ApplyDefaults(
                     invocation.InputPath!,
                     ref runCpu,
                     ref runMemory,

--- a/tests/Asynkron.Profiler.Tests/MemoryProfileResultFactoryTests.cs
+++ b/tests/Asynkron.Profiler.Tests/MemoryProfileResultFactoryTests.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class MemoryProfileResultFactoryTests
+{
+    [Fact]
+    public void Build_SortsEntriesAndCapsAtFifty()
+    {
+        var roots = Enumerable.Range(0, 55)
+            .Select(index => new AllocationCallTreeNode($"Type{index}")
+            {
+                Count = index + 1,
+                TotalBytes = index + 1
+            })
+            .ToArray();
+        var callTree = new AllocationCallTreeResult(roots.Sum(root => root.TotalBytes), roots.Sum(root => root.Count), roots);
+
+        var result = MemoryProfileResultFactory.Build(callTree);
+
+        Assert.Equal("1.50 KB", result.TotalAllocated);
+        Assert.Equal("1.50 KB", result.AllocationTotal);
+        Assert.Same(callTree, result.AllocationCallTree);
+        Assert.Equal(50, result.AllocationEntries.Count);
+        Assert.Equal("Type54", result.AllocationEntries[0].Type);
+        Assert.Equal("55 B", result.AllocationEntries[0].Total);
+        Assert.Equal("Type5", result.AllocationEntries[^1].Type);
+    }
+}

--- a/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfileInputLoaderTests.cs
@@ -9,40 +9,6 @@ namespace Asynkron.Profiler.Tests;
 public sealed class ProfileInputLoaderTests
 {
     [Fact]
-    public void ApplyInputDefaults_MapsExtensionsToExpectedModes()
-    {
-        AssertModes("trace.json", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: false, expectedContention: false);
-        AssertModes("trace.nettrace", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: true, expectedContention: true);
-        AssertModes("trace.etlx", expectedCpu: false, expectedMemory: true, expectedHeap: false, expectedException: true, expectedContention: true);
-        AssertModes("trace.gcdump", expectedCpu: false, expectedMemory: false, expectedHeap: true, expectedException: false, expectedContention: false);
-        AssertModes("trace.unknown", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: false, expectedContention: false);
-    }
-
-    [Fact]
-    public void BuildMemoryProfileResult_SortsEntriesAndCapsAtFifty()
-    {
-        var loader = CreateLoader((_, _) => true);
-        var roots = Enumerable.Range(0, 55)
-            .Select(index => new AllocationCallTreeNode($"Type{index}")
-            {
-                Count = index + 1,
-                TotalBytes = index + 1
-            })
-            .ToArray();
-        var callTree = new AllocationCallTreeResult(roots.Sum(root => root.TotalBytes), roots.Sum(root => root.Count), roots);
-
-        var result = ProfileInputLoader.BuildMemoryProfileResult(callTree);
-
-        Assert.Equal("1.50 KB", result.TotalAllocated);
-        Assert.Equal("1.50 KB", result.AllocationTotal);
-        Assert.Same(callTree, result.AllocationCallTree);
-        Assert.Equal(50, result.AllocationEntries.Count);
-        Assert.Equal("Type54", result.AllocationEntries[0].Type);
-        Assert.Equal("55 B", result.AllocationEntries[0].Total);
-        Assert.Equal("Type5", result.AllocationEntries[^1].Type);
-    }
-
-    [Fact]
     public void LoadHeap_UsesGcdumpLoaderWhenToolIsAvailable()
     {
         var messages = new List<string>();
@@ -98,43 +64,6 @@ public sealed class ProfileInputLoaderTests
         {
             File.Delete(unsupportedPath);
         }
-    }
-
-    [Fact]
-    public void BuildInputLabel_FallsBackToInputWhenFileNameIsMissing()
-    {
-        var label = ProfileInputLoader.BuildInputLabel(string.Empty);
-
-        Assert.Equal("input", label);
-    }
-
-    private static void AssertModes(
-        string inputPath,
-        bool expectedCpu,
-        bool expectedMemory,
-        bool expectedHeap,
-        bool expectedException,
-        bool expectedContention)
-    {
-        var runCpu = false;
-        var runMemory = false;
-        var runHeap = false;
-        var runException = false;
-        var runContention = false;
-
-        ProfileInputLoader.ApplyInputDefaults(
-            inputPath,
-            ref runCpu,
-            ref runMemory,
-            ref runHeap,
-            ref runException,
-            ref runContention);
-
-        Assert.Equal(expectedCpu, runCpu);
-        Assert.Equal(expectedMemory, runMemory);
-        Assert.Equal(expectedHeap, runHeap);
-        Assert.Equal(expectedException, runException);
-        Assert.Equal(expectedContention, runContention);
     }
 
     private static ProfileInputLoader CreateLoader(

--- a/tests/Asynkron.Profiler.Tests/ProfileInputPathTests.cs
+++ b/tests/Asynkron.Profiler.Tests/ProfileInputPathTests.cs
@@ -1,0 +1,66 @@
+using Xunit;
+
+namespace Asynkron.Profiler.Tests;
+
+public sealed class ProfileInputPathTests
+{
+    [Fact]
+    public void ApplyDefaults_MapsExtensionsToExpectedModes()
+    {
+        AssertModes("trace.json", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: false, expectedContention: false);
+        AssertModes("trace.nettrace", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: true, expectedContention: true);
+        AssertModes("trace.etlx", expectedCpu: false, expectedMemory: true, expectedHeap: false, expectedException: true, expectedContention: true);
+        AssertModes("trace.gcdump", expectedCpu: false, expectedMemory: false, expectedHeap: true, expectedException: false, expectedContention: false);
+        AssertModes("trace.unknown", expectedCpu: true, expectedMemory: false, expectedHeap: false, expectedException: false, expectedContention: false);
+    }
+
+    [Fact]
+    public void BuildLabel_FallsBackToInputWhenFileNameIsMissing()
+    {
+        var label = ProfileInputPath.BuildLabel(string.Empty);
+
+        Assert.Equal("input", label);
+    }
+
+    [Theory]
+    [InlineData("trace.json", "Speedscope")]
+    [InlineData("trace.nettrace", "NetTrace")]
+    [InlineData("trace.etlx", "Etlx")]
+    [InlineData("trace.gcdump", "Gcdump")]
+    [InlineData("trace.txt", "HeapReport")]
+    [InlineData("trace.log", "HeapReport")]
+    [InlineData("trace.bin", "Unknown")]
+    public void GetKind_ReturnsExpectedInputKind(string inputPath, string expectedKind)
+    {
+        Assert.Equal(expectedKind, ProfileInputPath.GetKind(inputPath).ToString());
+    }
+
+    private static void AssertModes(
+        string inputPath,
+        bool expectedCpu,
+        bool expectedMemory,
+        bool expectedHeap,
+        bool expectedException,
+        bool expectedContention)
+    {
+        var runCpu = false;
+        var runMemory = false;
+        var runHeap = false;
+        var runException = false;
+        var runContention = false;
+
+        ProfileInputPath.ApplyDefaults(
+            inputPath,
+            ref runCpu,
+            ref runMemory,
+            ref runHeap,
+            ref runException,
+            ref runContention);
+
+        Assert.Equal(expectedCpu, runCpu);
+        Assert.Equal(expectedMemory, runMemory);
+        Assert.Equal(expectedHeap, runHeap);
+        Assert.Equal(expectedException, runException);
+        Assert.Equal(expectedContention, runContention);
+    }
+}


### PR DESCRIPTION
﻿## Summary
- extract profile input classification, labeling, trace detection, and default mode selection into `ProfileInputPath` and `ProfileInputKind`
- extract allocation call-tree to memory-profile projection into `MemoryProfileResultFactory`
- simplify `ProfileInputLoader` so it focuses on file existence checks, heap/trace orchestration, and themed error reporting
- split the old loader tests into focused suites for loader behavior, input-path behavior, and memory result shaping

## Testing
- `roslynator fix src/ProfilerCore/Asynkron.Profiler.Core.csproj`
- `roslynator fix src/ProfileTool/ProfileTool.csproj`
- `roslynator fix tests/Asynkron.Profiler.Tests/Asynkron.Profiler.Tests.csproj`
- `dotnet format Asynkron.Profiler.sln --verify-no-changes`
- `dotnet build Asynkron.Profiler.sln -v minimal`
- `dotnet test Asynkron.Profiler.sln -v minimal`
- `quickdup -path . -ext .cs -select 0..30 -min 2 -exclude ".g.,.generated.,bin/,obj/"`